### PR TITLE
Add library kind and link database names to detail pages

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -41,7 +41,8 @@ const jsonLd = JSON.stringify({
       <li><b>Multiple</b> — Multi-model databases supporting more than one graph paradigm.</li>
       <li><b>Extension</b> — Graph capabilities added to an existing database system.</li>
       <li><b>Query Engine</b> — Standalone engines that query graph data from external sources.</li>
-      <li><b>Embedded</b> — Libraries designed for in-process graph storage and querying.</li>
+      <li><b>Embedded</b> — Databases designed for in-process graph storage and querying.</li>
+      <li><b>Library</b> — Programming libraries for RDF or graph data manipulation.</li>
     </ul>
     <p><b>Status:</b></p>
     <ul>

--- a/src/pages/db/[slug].astro
+++ b/src/pages/db/[slug].astro
@@ -26,7 +26,7 @@ if (db.data.icon) {
   }
 }
 
-const categoryLabel = `Graph ${db.data.kind === 'database' ? 'Database' : db.data.kind === 'extension' ? 'Database Extension' : db.data.kind === 'query-engine' ? 'Query Engine' : 'Embedded Database'}`;
+const categoryLabel = `Graph ${db.data.kind === 'database' ? 'Database' : db.data.kind === 'extension' ? 'Database Extension' : db.data.kind === 'query-engine' ? 'Query Engine' : db.data.kind === 'library' ? 'Library' : 'Embedded Database'}`;
 
 const pageJsonLd = JSON.stringify({
   "@context": "https://schema.org",
@@ -98,7 +98,7 @@ const description = db.data.description;
           <dt>Kind</dt>
           <dd>
             <span class={`badge badge-${db.data.kind}`}>
-              {db.data.kind === 'query-engine' ? 'Query Engine' : db.data.kind === 'extension' ? 'Extension' : 'Embedded'}
+              {db.data.kind === 'query-engine' ? 'Query Engine' : db.data.kind === 'extension' ? 'Extension' : db.data.kind === 'library' ? 'Library' : 'Embedded'}
             </span>
           </dd>
         </>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ const datasetSchema = JSON.stringify({
                   <span class="icon-placeholder" />
                 );
               })()}
-              <span class="has-tooltip" aria-label={db.data.description + (db.data.previous_names?.length ? `\nPreviously: ${db.data.previous_names.join(' → ')}` : '')} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{db.data.name}</span>
+              <a href={`/db/${db.data.slug}`} class="has-tooltip" aria-label={db.data.description + (db.data.previous_names?.length ? `\nPreviously: ${db.data.previous_names.join(' → ')}` : '')} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{db.data.name}</a>
               <span class="db-links">
                 {db.data.github_url ? (
                   <a href={db.data.github_url} target="_blank" rel="noopener noreferrer" title={db.data.github_url}>
@@ -200,7 +200,7 @@ const datasetSchema = JSON.stringify({
           <td>
             {db.data.kind !== 'database' ? (
               <span class={`badge badge-${db.data.kind}`}>
-                {db.data.kind === 'query-engine' ? 'Query Engine' : db.data.kind === 'extension' ? 'Extension' : 'Embedded'}
+                {db.data.kind === 'query-engine' ? 'Query Engine' : db.data.kind === 'extension' ? 'Extension' : db.data.kind === 'library' ? 'Library' : 'Embedded'}
               </span>
             ) : ''}
           </td>


### PR DESCRIPTION
- Add 'library' kind to schema and display across all pages
- Set Redland and RDFLib to kind=library
- Link database names in main table to /db/{slug} pages