### PR TITLE
Add agdb, Attean, RDF::Trine, and DozerDB database entries

### DIFF
--- a/src/content/databases/agdb.toml
+++ b/src/content/databases/agdb.toml
@@ -1,0 +1,12 @@
+name = "agdb"
+vendor = "Agnesoft"
+slug = "agdb"
+description = "An application-native graph database written in Rust using programmatic query builders instead of a text-based query language. Features ACID transactions, memory-mapped persistent storage, and client libraries for Rust, Python, TypeScript, PHP, Java, C, C++, and C#."
+url = "https://agdb.agnesoft.com/"
+github_url = "https://github.com/agnesoft/agdb"
+license = "Apache-2.0"
+type = "Property Graph"
+kind = "embedded"
+query_languages = ["Custom API"]
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/attean.toml
+++ b/src/content/databases/attean.toml
@@ -1,0 +1,12 @@
+name = "Attean"
+vendor = "Gregory Todd Williams"
+slug = "attean"
+description = "A Perl semantic web framework providing a SPARQL 1.1 query engine, in-memory triple/quad store, and parsers for multiple RDF serialization formats including Turtle, N-Triples, RDF/XML, and TriG."
+url = "https://metacpan.org/pod/Attean"
+github_url = "https://github.com/kasei/attean"
+license = "Artistic-2.0"
+type = "RDF"
+kind = "library"
+query_languages = ["SPARQL"]
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/dozerdb.toml
+++ b/src/content/databases/dozerdb.toml
@@ -1,0 +1,12 @@
+name = "DozerDB"
+vendor = "Graph Foundation"
+slug = "dozerdb"
+description = "A Neo4j Community Edition plugin that adds enterprise features including multi-database support, enterprise authentication and authorization, and backup/restore capabilities. Tracks Neo4j 5.x releases."
+url = "https://dozerdb.org/"
+github_url = "https://github.com/DozerDB/dozerdb-plugin"
+license = "GPL-3.0"
+type = "Property Graph"
+kind = "extension"
+query_languages = ["Cypher"]
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/rdf-trine.toml
+++ b/src/content/databases/rdf-trine.toml
@@ -1,0 +1,14 @@
+name = "RDF::Trine"
+vendor = "Gregory Todd Williams"
+slug = "rdf-trine"
+description = "A Perl RDF framework providing triple store abstractions with in-memory and DBI-backed (MySQL, PostgreSQL, SQLite) storage backends, plus parsers for RDF/XML, Turtle, RDFa, and RDF/JSON."
+url = "https://metacpan.org/pod/RDF::Trine"
+github_url = "https://github.com/kasei/perlrdf"
+license = "Artistic-2.0"
+type = "RDF"
+kind = "library"
+query_languages = ["SPARQL"]
+category = "Emerging"
+status = "inactive"
+status_note = "Deprecated in favour of the Attean framework. Last release was v1.019 in January 2018."
+gdotv_support = false


### PR DESCRIPTION
New graph database/library entries based on community suggestions:
- agdb: Rust embedded graph database (Emerging) #13 
- Attean: Perl SPARQL 1.1 RDF library (Emerging) #12 
- RDF::Trine: Perl RDF library, inactive/deprecated (Emerging) #12 
- DozerDB: Neo4j Community plugin adding enterprise features (Emerging) 