### PR TITLE
Add entry for KGLite

### DIFF
--- a/src/content/databases/kglite.toml
+++ b/src/content/databases/kglite.toml
@@ -1,0 +1,12 @@
+name = "KGLite"
+vendor = "Kristian dF Kollsgård"
+slug = "kglite"
+description = "An embedded knowledge graph for Python written in Rust. Speaks openCypher, ships with three storage modes (in-memory, mmap, disk-backed CSR), pandas DataFrame I/O, a code_tree parser that turns source trees into call graphs across 9 languages, and a bundled MCP server for LLM agents."
+url = "https://kglite.readthedocs.io"
+github_url = "https://github.com/kkollsga/kglite"
+license = "MIT"
+type = "Property Graph"
+kind = "embedded"
+query_languages = ["openCypher", "Custom API"]
+category = "Emerging"
+gdotv_support = false


### PR DESCRIPTION
## Summary
- Adds `src/content/databases/kglite.toml` for [KGLite](https://github.com/kkollsga/kglite), an embedded Python knowledge graph written in Rust.
- Speaks openCypher; three storage modes (in-memory, mmap, disk-backed CSR); MIT-licensed.
- Classed as `kind = "embedded"`, `type = "Property Graph"`, `category = "Emerging"` — sits alongside peers like `agdb` and `falkordblite`.

## Test plan
- [ ] `npm run build` produces the static site without TOML schema errors
- [ ] KGLite entry appears in the comparison table with vendor, license, query languages, and links rendering correctly