### PR TITLE
Rankings tables: db tooltips + GitHub/website links

### DIFF
--- a/src/components/IconDefs.astro
+++ b/src/components/IconDefs.astro
@@ -1,0 +1,15 @@
+---
+/**
+ * Inline SVG symbol defs used across the site (rendered hidden once per page).
+ * Reference with `<svg><use href="#icon-name" /></svg>`. Centralised here so
+ * pages don't re-declare the symbols and risk drift.
+ */
+---
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <symbol id="icon-github" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2"/>
+  </symbol>
+  <symbol id="icon-external" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
+  </symbol>
+</svg>

--- a/src/components/RankingTable.astro
+++ b/src/components/RankingTable.astro
@@ -10,13 +10,20 @@ interface LinkMaps {
   implementationLanguageSlug: Map<string, string>;
 }
 
+interface EngineMeta {
+  description: string;
+  githubUrl?: string;
+  url?: string;
+}
+
 interface Props {
   engines: RankedEngine[];
   scoreField?: 'score' | 'momentum';
   faviconMap?: Record<string, string>;
   linkMaps?: LinkMaps;
+  engineMeta?: Record<string, EngineMeta>;
 }
-const { engines, scoreField = 'score', faviconMap = {}, linkMaps } = Astro.props;
+const { engines, scoreField = 'score', faviconMap = {}, linkMaps, engineMeta = {} } = Astro.props;
 const scoreLabel = scoreField === 'momentum' ? 'Momentum' : 'Score';
 
 const hasDeltas = engines.some((e) => e.rankDelta1m !== null || e.rankDelta2m !== null);
@@ -69,10 +76,22 @@ const tierClass = (tier: string): string => {
             {hasDeltas && <td class={`num ${deltaClass(e.rankDelta1m)}`}>{fmtDelta(e.rankDelta1m)}</td>}
             {hasDeltas && <td class={`num ${deltaClass(e.rankDelta2m)}`}>{fmtDelta(e.rankDelta2m)}</td>}
             <td>
-              <a href={`/db/${e.slug}/`} class="name-link">
+              <div class="name-cell">
                 {fav && <img src={fav} alt="" width="16" height="16" class="favicon" loading="lazy" />}
-                <span>{e.name}</span>
-              </a>
+                <a href={`/db/${e.slug}/`} class="has-tooltip" aria-label={engineMeta[e.slug]?.description ?? e.name} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{e.name}</a>
+                <span class="db-links">
+                  {engineMeta[e.slug]?.githubUrl ? (
+                    <a href={engineMeta[e.slug]!.githubUrl} target="_blank" rel="noopener noreferrer" title={engineMeta[e.slug]!.githubUrl}>
+                      <svg width="14" height="14"><use href="#icon-github" /></svg>
+                    </a>
+                  ) : null}
+                  {engineMeta[e.slug]?.url ? (
+                    <a href={`${engineMeta[e.slug]!.url}${engineMeta[e.slug]!.url!.includes('?') ? '&' : '?'}utm_source=gdb-engines&utm_medium=referral`} target="_blank" rel="noopener noreferrer" title={engineMeta[e.slug]!.url}>
+                      <svg width="14" height="14"><use href="#icon-external" /></svg>
+                    </a>
+                  ) : null}
+                </span>
+              </div>
             </td>
             <td class="num">{(scoreField === 'momentum' ? e.momentum : e.score).toFixed(1)}</td>
             <td><span class={`badge ${tierClass(e.tier)}`}>{e.tier}</span></td>
@@ -137,7 +156,9 @@ const tierClass = (tier: string): string => {
   .ranking-table .rank-cell { padding-left: 0.5rem; padding-right: 0.5rem; width: 2.25rem; }
   .ranking-table a { color: inherit; text-decoration: none; }
   .ranking-table a:hover { text-decoration: underline; }
-  .ranking-table .name-link { display: inline-flex; align-items: center; gap: 0.5rem; }
+  /* Match the homepage's Name cell layout — favicon + tooltipped link + db-links
+     icon set. .has-tooltip and .db-links styling lives in global.css already. */
+  .ranking-table .name-cell { display: flex; align-items: center; gap: 0.5rem; }
   .ranking-table .favicon {
     width: 16px;
     height: 16px;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,6 @@
 ---
+import IconDefs from '../components/IconDefs.astro';
+
 interface Props {
   title: string;
   description?: string;
@@ -74,6 +76,7 @@ const siteSchema = JSON.stringify({
     </script>
   </head>
   <body>
+    <IconDefs />
     <slot />
     <script>
       import '../scripts/theme.ts';

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -60,14 +60,6 @@ const jsonLd = JSON.stringify({
   jsonLd={[jsonLd]}
   description={`Compare ${databases.length}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings. Data backed by academic research.`}
 >
-  <svg xmlns="http://www.w3.org/2000/svg" style="display:none">
-    <symbol id="icon-github" viewBox="0 0 24 24">
-      <path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2"/>
-    </symbol>
-    <symbol id="icon-external" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/>
-    </symbol>
-  </svg>
   <header>
     <div class="left">
       <a href="/" class="header-home" aria-label="GDB-Engines home">

--- a/src/pages/rankings/[slug].astro
+++ b/src/pages/rankings/[slug].astro
@@ -19,8 +19,11 @@ export async function getStaticPaths() {
 
   // Build the favicon map once and share across all board pages (fetchFavicon caches
   // on disk, but the catalog walk is per-build so we hoist it out of the per-page render).
+  // Same shared pass collects engine descriptions + github/website URLs for tooltips
+  // and link icons on the rankings table — same affordance as the homepage Name column.
   const databases = await getCollection('databases');
   const faviconMap: Record<string, string> = {};
+  const engineMeta: Record<string, { description: string; githubUrl?: string; url?: string }> = {};
   for (const db of databases) {
     if (db.data.icon) {
       faviconMap[db.data.slug] = `/logos/${db.data.icon}`;
@@ -28,6 +31,11 @@ export async function getStaticPaths() {
       const result = await fetchFavicon(db.data.slug, db.data.url ?? '', db.data.github_url);
       faviconMap[db.data.slug] = result.url;
     }
+    engineMeta[db.data.slug] = {
+      description: db.data.description ?? '',
+      githubUrl: db.data.github_url,
+      url: db.data.url,
+    };
   }
 
   return buildBoards(ranking).map((board) => ({
@@ -38,11 +46,12 @@ export async function getStaticPaths() {
       sponsor: getSponsor(sponsors, board.slug),
       faviconMap,
       linkMaps,
+      engineMeta,
     },
   }));
 }
 
-const { board, generatedAt, sponsor, faviconMap, linkMaps } = Astro.props;
+const { board, generatedAt, sponsor, faviconMap, linkMaps, engineMeta } = Astro.props;
 const canonical = `https://gdb-engines.com/rankings/${board.slug}/`;
 const ogImage = `https://gdb-engines.com/og/rankings/${board.slug}.png`;
 const updated = new Date(generatedAt).toLocaleDateString('en-GB', { year: 'numeric', month: 'long' });
@@ -94,7 +103,7 @@ const scoreLabel = isMovers ? 'momentum' : 'score';
 
     {sponsor && <SponsorSlot sponsor={sponsor} />}
 
-    <RankingTable engines={board.engines} scoreField={isMovers ? 'momentum' : 'score'} faviconMap={faviconMap} linkMaps={linkMaps} />
+    <RankingTable engines={board.engines} scoreField={isMovers ? 'momentum' : 'score'} faviconMap={faviconMap} linkMaps={linkMaps} engineMeta={engineMeta} />
     {board.insufficientCount > 0 && (
       <p class="insufficient-note">
         {board.insufficientCount} additional {board.insufficientCount === 1 ? 'engine has' : 'engines have'} too little public signal to be ranked.


### PR DESCRIPTION
Same affordance as the homepage Name column on every rankings table — engine description on hover, GitHub + external-site icons. Reuses existing has-tooltip + db-links CSS; no duplication. Shared IconDefs component included via Layout so every page has the icons.