### PR TITLE
Route Seline analytics through first-party proxy

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.seline.so; connect-src 'self' https://cdn.seline.so; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://sln.gdb-engines.com; connect-src 'self' https://sln.gdb-engines.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'
 
 # Content-hashed Astro bundles never change at the same URL — long-cache.
 /_astro/*

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -66,7 +66,8 @@ const siteSchema = JSON.stringify({
     ))}
     {selineToken && (
       <script
-        src="https://cdn.seline.so/seline.js"
+        src="https://sln.gdb-engines.com/ennui.js"
+        data-api-host="https://sln.gdb-engines.com"
         data-token={selineToken}
         async
       />


### PR DESCRIPTION
Fixes analytics, which stopped recording on 2026-05-28 when a CSP blocked Seline's event beacons.

Routes Seline through the first-party proxy on `sln.gdb-engines.com`: the script and its beacons are now same-site, and the CSP references a single origin.