### PR TITLE
Add RelationalAI

### DIFF
--- a/src/content/databases/relationalai.toml
+++ b/src/content/databases/relationalai.toml
@@ -1,0 +1,12 @@
+name = "RelationalAI"
+vendor = "RelationalAI"
+slug = "relationalai"
+description = "A cloud-native relational knowledge graph system (RKGS) that models all data as relations in Graph Normal Form and is queried with Rel, a declarative, Datalog-based modeling language. Positioned as a knowledge graph coprocessor for Snowflake, it runs in-account as a Native App on Snowpark Container Services, adding rule-based reasoning, graph analytics, and predictive and prescriptive analytics over data where it already lives. The engine is built in Julia."
+url = "https://relational.ai/"
+license = "Proprietary"
+implementation_language = "Julia"
+type = "Other"
+query_languages = ["Rel", "SQL"]
+released = "2021"
+category = "Growing"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-06-01</dt>
+      <dd>Added RelationalAI, a relational knowledge graph system queried with Rel and built in Julia.</dd>
       <dt>2026-05-28</dt>
       <dd>Launched <a href="/rankings/">GDB-Engines Rankings</a>: monthly popularity boards across data model, engine kind, license, query language, and implementation language, plus an overall board and a movers board.</dd>
       <dt>2026-05-27</dt>


### PR DESCRIPTION
Adds RelationalAI — a cloud-native relational knowledge graph system (RKGS) queried with Rel (Datalog-based), running as a Snowflake Native App. Built in Julia, proprietary.

Classification calls: `type = Other` (relational/Datalog, not property-graph or RDF), `category = Growing`, `released = 2021` (first public availability; Snowflake Native App came 2024). No `[features]` block, matching recent commercial entries.