### PR TITLE
Drop rankings arrow, unify db count, fix dark-mode contrast

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An Open Source comparison of graph database features and capabilities.
 
 ## Overview
 
-A comprehensive comparison table covering 80+ graph databases, query engines, extensions, and other graph technologies. Each entry includes metadata like vendor, license, query language support, and status. Many entries are also scored across 43 features based on criteria from academic research.
+A comprehensive comparison table covering 131+ graph databases, query engines, extensions, and other graph technologies. Each entry includes metadata like vendor, license, query language support, and status. Many entries are also scored across 43 features based on criteria from academic research.
 
 ## Data format
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,10 +1,10 @@
 # GDB-Engines
 
-> Open-source comparison and monthly popularity ranking of 130+ graph databases, query engines, extensions, and embedded libraries. Covers property graph (LPG), RDF, and multi-model engines. Feature scores derived from peer-reviewed academic research; popularity rankings blended monthly across adoption, activity, community and research signals from public sources.
+> Open-source comparison and monthly popularity ranking of 131+ graph databases, query engines, extensions, and embedded libraries. Covers property graph (LPG), RDF, and multi-model engines. Feature scores derived from peer-reviewed academic research; popularity rankings blended monthly across adoption, activity, community and research signals from public sources.
 
 ## Comparison
 
-- [Homepage](https://gdb-engines.com/): Interactive comparison of 130+ graph databases with 43 academic feature scores, license, query languages, implementation language, and overall popularity rank.
+- [Homepage](https://gdb-engines.com/): Interactive comparison of 131+ graph databases with 43 academic feature scores, license, query languages, implementation language, and overall popularity rank.
 - [About](https://gdb-engines.com/about): Methodology, data model, contribution guidelines, changelog.
 - [JSON API](https://gdb-engines.com/api.json): Full dataset.
 

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -20,7 +20,6 @@
         <rect x="11" y="2" width="3" height="12" rx="0.5"/>
       </svg>
       <span class="rankings-link__label">Rankings</span>
-      <span class="rankings-link__arrow" aria-hidden="true">↪</span>
     </a>
     <slot name="left" />
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,6 @@
 ---
 import IconDefs from '../components/IconDefs.astro';
+import { getDatabaseCount } from '../lib/database-count';
 
 interface Props {
   title: string;
@@ -8,7 +9,8 @@ interface Props {
   canonical?: string;
   ogImage?: string;
 }
-const { title, description = 'Compare 130+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings. Data backed by academic research.', jsonLd = [], canonical = 'https://gdb-engines.com/', ogImage = 'https://gdb-engines.com/og.png' } = Astro.props;
+const dbCount = await getDatabaseCount();
+const { title, description = `Compare ${dbCount}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings.`, jsonLd = [], canonical = 'https://gdb-engines.com/', ogImage = 'https://gdb-engines.com/og.png' } = Astro.props;
 const selineToken = import.meta.env.PUBLIC_SELINE_TOKEN;
 
 const siteSchema = JSON.stringify({
@@ -16,7 +18,7 @@ const siteSchema = JSON.stringify({
   "@type": "WebSite",
   "name": "GDB-Engines",
   "url": "https://gdb-engines.com",
-  "description": "Compare 130+ graph databases side-by-side with monthly popularity rankings. Data backed by academic research.",
+  "description": `Compare ${dbCount}+ graph databases side-by-side with monthly popularity rankings.`,
   "publisher": {
     "@type": "Organization",
     "name": "GDB-Engines",

--- a/src/lib/database-count.ts
+++ b/src/lib/database-count.ts
@@ -1,0 +1,11 @@
+import { getCollection } from 'astro:content';
+
+/**
+ * Total number of database entries.
+ *
+ * Single source for the count figure shown across page titles, meta
+ * descriptions, and structured data so the number never drifts between pages.
+ */
+export async function getDatabaseCount(): Promise<number> {
+  return (await getCollection('databases')).length;
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -56,9 +56,9 @@ const jsonLd = JSON.stringify({
 });
 ---
 <Layout
-  title="GDB-Engines — Compare 130+ Graph Databases"
+  title={`GDB-Engines — Compare ${databases.length}+ Graph Databases`}
   jsonLd={[jsonLd]}
-  description={`Compare ${databases.length}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings. Data backed by academic research.`}
+  description={`Compare ${databases.length}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings.`}
 >
   <header>
     <div class="left">
@@ -68,7 +68,7 @@ const jsonLd = JSON.stringify({
         <span class="header-brand">GDB-Engines</span>
       </a>
       <span class="slash"></span>
-      <p>An Open Source list and comparison of <span id="db-count">{databases.length}</span> graph databases</p>
+      <p>Compare <span id="db-count">{databases.length}</span> graph databases</p>
       <a href="/rankings/" class="rankings-link" aria-label="Monthly graph database popularity rankings">
         <svg class="rankings-link__icon" width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <rect x="2" y="9" width="3" height="5" rx="0.5"/>
@@ -76,7 +76,6 @@ const jsonLd = JSON.stringify({
           <rect x="11" y="2" width="3" height="12" rx="0.5"/>
         </svg>
         <span class="rankings-link__label">Rankings</span>
-        <span class="rankings-link__arrow" aria-hidden="true">↪</span>
       </a>
     </div>
     <div class="right">

--- a/src/pages/sponsor.astro
+++ b/src/pages/sponsor.astro
@@ -2,6 +2,9 @@
 import Layout from '../layouts/Layout.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import '../styles/global.css';
+import { getDatabaseCount } from '../lib/database-count';
+
+const dbCount = await getDatabaseCount();
 ---
 <Layout
   title="Sponsor GDB-Engines Rankings"
@@ -12,7 +15,7 @@ import '../styles/global.css';
   <main class="sponsor-page">
     <h1>Sponsor GDB-Engines Rankings</h1>
 
-    <p>GDB-Engines Rankings publishes monthly popularity boards covering ~130 graph databases across data model, query language, implementation language and license.</p>
+    <p>GDB-Engines Rankings publishes monthly popularity boards covering {dbCount}+ graph databases across data model, query language, implementation language and license.</p>
 
     <p>If you'd like to sponsor a ranking page please get in touch:</p>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -253,7 +253,7 @@ header {
   transition: background-color 120ms ease;
 }
 .ranks-list a:hover { background-color: color-mix(in srgb, var(--color-brand) 12%, var(--color-surface)); }
-.ranks-list .rank { font-weight: 600; color: var(--color-brand); font-variant-numeric: tabular-nums; }
+.ranks-list .rank { font-weight: 600; color: var(--color-brand-accent); font-variant-numeric: tabular-nums; }
 .ranks-list .label { color: var(--color-text-secondary); }
 
 /* Rankings cross-links from the comparison table */
@@ -281,7 +281,7 @@ th.rank-col { padding-left: 0.5rem; padding-right: 0.5rem; }
 .rank-delta { margin-left: 0.35rem; font-size: 0.7rem; font-weight: 500; }
 .rank-delta.delta-up { color: #2b8a3e; }
 .rank-delta.delta-down { color: #c92a2a; }
-.rank-delta.delta-new { color: var(--color-brand); }
+.rank-delta.delta-new { color: var(--color-brand-accent); }
 @media (prefers-color-scheme: dark) {
   .rank-delta.delta-up { color: #80c889; }
   .rank-delta.delta-down { color: #ff7a7a; }
@@ -319,12 +319,6 @@ th.rank-col { padding-left: 0.5rem; padding-right: 0.5rem; }
   background-color: color-mix(in srgb, var(--color-brand-accent) 26%, transparent);
 }
 .rankings-link__icon { flex-shrink: 0; }
-/* ↪ glyph sits high on its line — nudge it down to the visual baseline. */
-.rankings-link__arrow { display: inline-block; transform: translateY(4px); font-size: 0.95em; }
-.rankings-link:hover .rankings-link__arrow { transform: translate(2px, 4px); }
-@media (hover: hover) {
-  .rankings-link__arrow { transition: transform 120ms ease; }
-}
 @media (max-width: 45rem) {
   .rankings-link__label { display: none; }
 }
@@ -624,20 +618,20 @@ tr.row-deprecated:hover td {
 }
 
 /* Dark mode badge colors — use custom properties to avoid duplication */
-.badge-property-graph { --badge-bg-dark: #1A2744; --badge-fg-dark: #64B5F6; }
-.badge-rdf { --badge-bg-dark: #2A1A33; --badge-fg-dark: #CE93D8; }
-.badge-multiple { --badge-bg-dark: #2E1A00; --badge-fg-dark: #FFB74D; }
-.badge-other { --badge-bg-dark: #1A2E0A; --badge-fg-dark: #AED581; }
-.badge-established { --badge-bg-dark: #1A2E1A; --badge-fg-dark: #81C784; }
-.badge-enterprise { --badge-bg-dark: #1A2744; --badge-fg-dark: #64B5F6; }
-.badge-growing { --badge-bg-dark: #0A2E2A; --badge-fg-dark: #80CBC4; }
-.badge-emerging { --badge-bg-dark: #2E2600; --badge-fg-dark: #FFD54F; }
-.badge-extension { --badge-bg-dark: #1A1A3E; --badge-fg-dark: #9FA8DA; }
-.badge-query-engine { --badge-bg-dark: #0A2E2E; --badge-fg-dark: #80CBC4; }
-.badge-embedded { --badge-bg-dark: #2E1A00; --badge-fg-dark: #FFB74D; }
-.badge-query-lang { --badge-bg-dark: #2A2A2A; --badge-fg-dark: #BBB; }
-.badge-inactive { --badge-bg-dark: #333; --badge-fg-dark: #9E9E9E; }
-.badge-deprecated { --badge-bg-dark: #3E1A1A; --badge-fg-dark: #EF9A9A; }
+.badge-property-graph { --badge-bg-dark: #24365E; --badge-fg-dark: #64B5F6; }
+.badge-rdf { --badge-bg-dark: #4A3357; --badge-fg-dark: #CE93D8; }
+.badge-multiple { --badge-bg-dark: #523100; --badge-fg-dark: #FFB74D; }
+.badge-other { --badge-bg-dark: #294612; --badge-fg-dark: #AED581; }
+.badge-established { --badge-bg-dark: #21421F; --badge-fg-dark: #81C784; }
+.badge-enterprise { --badge-bg-dark: #24365E; --badge-fg-dark: #64B5F6; }
+.badge-growing { --badge-bg-dark: #103F39; --badge-fg-dark: #80CBC4; }
+.badge-emerging { --badge-bg-dark: #4A3F00; --badge-fg-dark: #FFD54F; }
+.badge-extension { --badge-bg-dark: #313167; --badge-fg-dark: #9FA8DA; }
+.badge-query-engine { --badge-bg-dark: #103F39; --badge-fg-dark: #80CBC4; }
+.badge-embedded { --badge-bg-dark: #523100; --badge-fg-dark: #FFB74D; }
+.badge-query-lang { --badge-bg-dark: #383838; --badge-fg-dark: #BBB; }
+.badge-inactive { --badge-bg-dark: #383838; --badge-fg-dark: #AAA; }
+.badge-deprecated { --badge-bg-dark: #6B2C2C; --badge-fg-dark: #EF9A9A; }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .badge { background: var(--badge-bg-dark); color: var(--badge-fg-dark); }
@@ -654,7 +648,7 @@ tr.row-deprecated:hover td {
 }
 .bar-fill {
   height: 100%;
-  background: var(--color-brand);
+  background: var(--color-brand-accent);
   border-radius: 0.25rem;
 }
 


### PR DESCRIPTION
Removes the arrow from the Rankings header button, makes the database count dynamic and consistent across pages, drops the academic-research meta fragment, and fixes low-contrast chips, rank numbers, and score bars in dark mode.