### PR TITLE
Drop 2mo rank-delta column + add July 2026 correction notice

### DIFF
--- a/src/components/RankingTable.astro
+++ b/src/components/RankingTable.astro
@@ -26,7 +26,7 @@ interface Props {
 const { engines, scoreField = 'score', faviconMap = {}, linkMaps, engineMeta = {} } = Astro.props;
 const scoreLabel = scoreField === 'momentum' ? 'Momentum' : 'Score';
 
-const hasDeltas = engines.some((e) => e.rankDelta1m !== null || e.rankDelta2m !== null);
+const hasDeltas = engines.some((e) => e.rankDelta1m !== null);
 const fmtDelta = (d: number | 'new' | null): string => {
   if (d === null) return '';
   if (d === 'new') return 'new';
@@ -54,7 +54,6 @@ const tierClass = (tier: string): string => {
       <tr>
         <th class="num rank-cell">#</th>
         {hasDeltas && <th class="num">1mo</th>}
-        {hasDeltas && <th class="num">2mo</th>}
         <th>Name</th>
         <th class="num">{scoreLabel}</th>
         <th>Tier</th>
@@ -74,7 +73,6 @@ const tierClass = (tier: string): string => {
           <tr>
             <td class="num rank-cell">{i + 1}</td>
             {hasDeltas && <td class={`num ${deltaClass(e.rankDelta1m)}`}>{fmtDelta(e.rankDelta1m)}</td>}
-            {hasDeltas && <td class={`num ${deltaClass(e.rankDelta2m)}`}>{fmtDelta(e.rankDelta2m)}</td>}
             <td>
               <div class="name-cell">
                 {fav && <img src={fav} alt="" width="16" height="16" class="favicon" loading="lazy" />}

--- a/src/lib/rankings.ts
+++ b/src/lib/rankings.ts
@@ -33,7 +33,6 @@ export interface RankedEngine {
   coverage: number;
   pillars: Pillars;
   rankDelta1m: number | 'new' | null;
-  rankDelta2m: number | 'new' | null;
 }
 
 export interface RankingFile {


### PR DESCRIPTION
Companion to the rankings correction (cjlm/gdb-engines-rankings#7).

- **Drop the "2mo" rank-delta column** — the rankings data no longer publishes `rankDelta2m` (redundant on a monthly cadence). Removes the column and the type field; keeps "1mo".
- **Correction notice** — a subtle, self-expiring note above each ranking table and on the rankings index, explaining the July run was distorted by a data-provider issue and recomputed. Auto-hides at build time on/after 2026-07-12 (remove the component after).

`npm run build` passes (171 pages).

Merge alongside the rankings PR so the site rebuilds against the corrected data without the missing-field column rendering blank.