### PR TITLE
Add July 2026 correction notice to ranking pages

### DIFF
--- a/src/components/CorrectionNotice.astro
+++ b/src/components/CorrectionNotice.astro
@@ -7,9 +7,8 @@ const show = new Date() < EXPIRES;
 ---
 {show && (
   <aside class="correction-notice" role="note">
-    <strong>Correction — July 2026.</strong> The initial July run under-collected research and
-    community-mention data for many engines, which distorted some positions. These tables have
-    been recomputed with corrected data. See the <a href="/about/">methodology</a>.
+    <strong>Correction — July 2026.</strong> Due to an unforeseen data-provider issue, the July
+    ranking was distorted by missing data. These tables have been recomputed with corrected data.
   </aside>
 )}
 

--- a/src/components/CorrectionNotice.astro
+++ b/src/components/CorrectionNotice.astro
@@ -1,0 +1,31 @@
+---
+// Transient notice about the July 2026 data-collection correction. Self-expires
+// at build time on/after EXPIRES, so a rebuild after that date drops it with no
+// code change needed (remove this component and its usages once past the date).
+const EXPIRES = new Date('2026-07-12T00:00:00Z');
+const show = new Date() < EXPIRES;
+---
+{show && (
+  <aside class="correction-notice" role="note">
+    <strong>Correction — July 2026.</strong> The initial July run under-collected research and
+    community-mention data for many engines, which distorted some positions. These tables have
+    been recomputed with corrected data. See the <a href="/about/">methodology</a>.
+  </aside>
+)}
+
+<style>
+  .correction-notice {
+    max-width: 70ch;
+    margin: 0 0 1.25rem;
+    padding: 0.6rem 0.85rem;
+    font-size: 0.85rem;
+    line-height: 1.45;
+    color: var(--color-text-secondary);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-left: 3px solid var(--color-text-tertiary);
+    border-radius: 4px;
+  }
+  .correction-notice strong { color: var(--color-text); font-weight: 600; }
+  .correction-notice a { color: inherit; text-decoration: underline; }
+</style>

--- a/src/pages/rankings/[slug].astro
+++ b/src/pages/rankings/[slug].astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import SiteHeader from '../../components/SiteHeader.astro';
 import RankingTable from '../../components/RankingTable.astro';
+import CorrectionNotice from '../../components/CorrectionNotice.astro';
 import SponsorCTA from '../../components/SponsorCTA.astro';
 import SponsorSlot from '../../components/SponsorSlot.astro';
 import '../../styles/global.css';
@@ -102,6 +103,8 @@ const scoreLabel = isMovers ? 'momentum' : 'score';
     <SponsorCTA />
 
     {sponsor && <SponsorSlot sponsor={sponsor} />}
+
+    <CorrectionNotice />
 
     <RankingTable engines={board.engines} scoreField={isMovers ? 'momentum' : 'score'} faviconMap={faviconMap} linkMaps={linkMaps} engineMeta={engineMeta} />
     {board.insufficientCount > 0 && (

--- a/src/pages/rankings/index.astro
+++ b/src/pages/rankings/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import SiteHeader from '../../components/SiteHeader.astro';
 import SponsorCTA from '../../components/SponsorCTA.astro';
+import CorrectionNotice from '../../components/CorrectionNotice.astro';
 import '../../styles/global.css';
 import { loadRankings } from '../../lib/rankings';
 import { buildBoards, type Board } from '../../lib/ranking-boards';
@@ -56,6 +57,8 @@ const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'lice
       <p class="lead">Monthly popularity rankings for graph databases — blended scores across adoption, activity, community and research signals.</p>
     )}
     <SponsorCTA />
+
+    <CorrectionNotice />
 
     {boards.length === 0 ? (
       <p class="empty">Ranking data isn't available in this build (no <code>RANKINGS_TOKEN</code> set and no local sibling checkout).</p>


### PR DESCRIPTION
The correction notice didn't make it into #53 (that squash landed before these commits). Adds it now.

Subtle, self-expiring note above each ranking table and on the rankings index: "Due to an unforeseen data-provider issue, the July ranking was distorted by missing data. These tables have been recomputed with corrected data." Auto-hides at build time on/after 2026-07-12 (delete the component after).

`npm run build` passes (171 pages; notice on 32 ranking pages).