### PR TITLE
Fix internal links to use canonical trailing-slash URLs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,6 +8,9 @@ const buildDate = new Date().toISOString().split('T')[0];
 export default defineConfig({
   output: 'static',
   site: 'https://gdb-engines.com',
+  // Canonical URLs carry a trailing slash (directory build format). Enforce it
+  // so a no-slash internal link is a build error, not a silent 301 redirect.
+  trailingSlash: 'always',
   integrations: [
     sitemap({
       serialize(item) {

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -28,6 +28,6 @@
       <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
       <svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
     </button>
-    <a href="/about" class="header-link">About</a>
+    <a href="/about/" class="header-link">About</a>
   </div>
 </header>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -170,7 +170,7 @@ const jsonLd = JSON.stringify({
                   <span class="icon-placeholder" />
                 );
               })()}
-              <a href={`/db/${db.data.slug}`} class="has-tooltip" aria-label={db.data.description + (db.data.previous_names?.length ? `\nPreviously: ${db.data.previous_names.join(' → ')}` : '')} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{db.data.name}</a>
+              <a href={`/db/${db.data.slug}/`} class="has-tooltip" aria-label={db.data.description + (db.data.previous_names?.length ? `\nPreviously: ${db.data.previous_names.join(' → ')}` : '')} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{db.data.name}</a>
               <span class="db-links">
                 {db.data.github_url ? (
                   <a href={db.data.github_url} target="_blank" rel="noopener noreferrer" title={db.data.github_url}>
@@ -287,7 +287,7 @@ const jsonLd = JSON.stringify({
   <footer class="site-footer">
     <span>Last updated: {new Date().toISOString().split('T')[0]}</span>
     <span><a href="/rankings/">Rankings</a></span>
-    <span><a href="/about">About & Changelog</a></span>
+    <span><a href="/about/">About & Changelog</a></span>
   </footer>
 
   <dialog id="modal">
@@ -327,7 +327,7 @@ const jsonLd = JSON.stringify({
     </div>
     <div class="footer">
       <a href="/rankings/">Rankings</a>
-      <a href="/about">About &amp; Changelog</a>
+      <a href="/about/">About &amp; Changelog</a>
       <a href="mailto:contact@gdb-engines.com">contact@gdb-engines.com</a>
       <a href="https://github.com/cjlm/gdb-engines" target="_blank" rel="noopener noreferrer">Edit on GitHub</a>
     </div>


### PR DESCRIPTION
Homepage engine links (`/db/<slug>`) and About links pointed to no-slash URLs that 301-redirect to their canonical slash versions. Google crawled the redirect forms, producing 121 "Page with redirect" entries in Search Console coverage.

- Point the links directly at canonical `/db/<slug>/` and `/about/` URLs
- Set `trailingSlash: 'always'` so a no-slash internal link fails the build instead of silently 301-ing