### PR TITLE
Honest sitemap lastmod, Dataset schema, www redirect

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,50 @@
 import { defineConfig } from 'astro/config';
 import sitemap from '@astrojs/sitemap';
+import { execSync } from 'node:child_process';
 
-// Stamp the build date as lastmod for every URL. Honest signal for a static
-// catalog where TOML edits and monthly ranking refreshes both trigger a rebuild.
+// Fallback for pages whose real change date can't be derived from git.
 const buildDate = new Date().toISOString().split('T')[0];
+
+/** Last git commit date (YYYY-MM-DD) touching any of `paths`, or null if unavailable. */
+function gitDate(...paths) {
+  try {
+    const quoted = paths.map((p) => `'${p}'`).join(' ');
+    const out = execSync(`git log -1 --format=%cs -- ${quoted}`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return /^\d{4}-\d{2}-\d{2}$/.test(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
+/** slug -> last commit date of its TOML source, built with one git-log pass. */
+function databaseDates() {
+  const dates = new Map();
+  try {
+    const log = execSync('git log --format=%cs --name-only -- src/content/databases', {
+      encoding: 'utf8',
+      maxBuffer: 32 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    let commitDate = null;
+    for (const line of log.split('\n')) {
+      if (/^\d{4}-\d{2}-\d{2}$/.test(line)) {
+        commitDate = line;
+      } else {
+        const slug = line.match(/^src\/content\/databases\/(.+)\.toml$/)?.[1];
+        if (slug && commitDate && !dates.has(slug)) dates.set(slug, commitDate);
+      }
+    }
+  } catch {
+    // git history unavailable (e.g. a shallow CI clone) — callers fall back to buildDate.
+  }
+  return dates;
+}
+
+const dbDates = databaseDates();
+const homepageDate = gitDate('src/content/databases', 'src/pages/index.astro') ?? buildDate;
 
 export default defineConfig({
   output: 'static',
@@ -13,14 +54,24 @@ export default defineConfig({
   trailingSlash: 'always',
   integrations: [
     sitemap({
+      // Report an honest per-page lastmod so unchanged pages don't claim freshness
+      // on every rebuild (which trains Google to ignore lastmod entirely).
       serialize(item) {
-        item.lastmod = buildDate;
-        if (item.url.includes('/rankings/')) {
+        const path = new URL(item.url).pathname;
+        const dbSlug = path.match(/^\/db\/(.+)\/$/)?.[1];
+        if (path.startsWith('/rankings/')) {
+          // Rankings regenerate from a monthly data refresh, so the build date is honest.
+          item.lastmod = buildDate;
           item.changefreq = 'monthly';
           item.priority = 0.8;
-        } else if (item.url.includes('/db/')) {
+        } else if (dbSlug) {
+          item.lastmod = dbDates.get(dbSlug) ?? buildDate;
           item.changefreq = 'yearly';
           item.priority = 0.6;
+        } else if (path === '/') {
+          item.lastmod = homepageDate;
+        } else {
+          item.lastmod = gitDate(`src/pages${path.replace(/\/$/, '')}.astro`) ?? buildDate;
         }
         return item;
       },

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,10 @@
 # Redirects for legacy/brand-friendly URLs not in the build output.
 # Cloudflare Pages format: <source> <destination> <status>
 
+# Canonical host is the apex. Send the www custom domain to it so the two hosts
+# don't split indexing. Requires www.gdb-engines.com to be attached to this project.
+https://www.gdb-engines.com/* https://gdb-engines.com/:splat 301
+
 # FalkorDB's catalog slug carries its legacy Redis history (`redisgraph-falkordb`).
 # Searches for "FalkorDB" should land on its page directly.
 /db/falkordb        /db/redisgraph-falkordb/        301

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -54,10 +54,30 @@ const jsonLd = JSON.stringify({
     "name": db.data.name,
   })),
 });
+
+// Dataset schema exposes the catalog to Google Dataset Search, with api.json as the
+// machine-readable distribution.
+const datasetJsonLd = JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "Dataset",
+  "name": "Graph Database Engines Comparison",
+  "description": `Structured comparison of ${databases.length}+ graph databases, extensions, and query engines — features, licenses, query languages, implementation languages, and monthly popularity rankings.`,
+  "url": "https://gdb-engines.com",
+  "keywords": ["graph database", "database comparison", "query language", "Cypher", "Gremlin", "SPARQL", "GQL", "SQL/PGQ"],
+  "creator": { "@type": "Organization", "name": "GDB-Engines", "url": "https://gdb-engines.com" },
+  "license": "https://github.com/cjlm/gdb-engines/blob/main/LICENSE",
+  "isAccessibleForFree": true,
+  "dateModified": new Date().toISOString().split('T')[0],
+  "distribution": [{
+    "@type": "DataDownload",
+    "encodingFormat": "application/json",
+    "contentUrl": "https://gdb-engines.com/api.json",
+  }],
+});
 ---
 <Layout
   title={`GDB-Engines — Compare ${databases.length}+ Graph Databases`}
-  jsonLd={[jsonLd]}
+  jsonLd={[jsonLd, datasetJsonLd]}
   description={`Compare ${databases.length}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings.`}
 >
   <header>


### PR DESCRIPTION
Three SEO refinements following the coverage cleanup.

**Sitemap `lastmod`** — previously every URL was stamped with the build date on each deploy, so unchanged pages claimed freshness and Google learns to ignore `lastmod`. Now db pages derive `lastmod` from their TOML's last git commit; rankings/homepage keep the build date (they genuinely regenerate from the monthly data refresh). Falls back to build date if git history is unavailable.

**Dataset schema** — adds `schema.org/Dataset` to the homepage with `api.json` as the distribution, making the catalog eligible for Google Dataset Search.

**www redirect** — `www.gdb-engines.com` has been attached to the Pages project (DNS auto-created; cert provisioning). This `_redirects` rule 301s it to the apex so the two hosts don't split indexing.