### PR TITLE
Add Truespar Traverse and Grust

### DIFF
--- a/src/content/databases/grust.toml
+++ b/src/content/databases/grust.toml
@@ -1,0 +1,13 @@
+name = "Grust"
+vendor = "QueryGraph"
+slug = "grust"
+description = "A backend-neutral property graph API for Rust that models graphs as labeled nodes and edges with typed properties, expressing traversals as an intermediate representation rather than a query-language string. Ships an async GraphStore trait with adapters for SurrealDB, HelixDB, FalkorDB, LanceDB, PostgreSQL, Turso, and Spark, plus a deterministic in-memory store."
+github_url = "https://github.com/querygraph/grust"
+license = "Apache-2.0"
+implementation_language = "Rust"
+type = "Property Graph"
+kind = "library"
+query_languages = ["Custom API"]
+released = "2026-05"
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/traverse.toml
+++ b/src/content/databases/traverse.toml
@@ -1,0 +1,13 @@
+name = "Traverse"
+vendor = "Truespar"
+slug = "traverse"
+description = "An in-memory property graph database written in Rust, speaking Cypher and GQL over the Bolt protocol for Neo4j driver compatibility. Includes a built-in graph data science library of 36+ algorithms callable from Cypher, and runs as a server, an embedded in-process library, a Cloud Hypervisor/Firecracker unikernel, or entirely in the browser via WebAssembly."
+url = "https://truespar.com/traverse"
+license = "Proprietary"
+implementation_language = "Rust"
+type = "Property Graph"
+kind = "database"
+query_languages = ["openCypher", "GQL"]
+released = "2026-03"
+category = "Emerging"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-07-13</dt>
+      <dd>Added Truespar Traverse and Grust.</dd>
       <dt>2026-06-20</dt>
       <dd>Added TurboLynx, GraphQLite, Bitsy, froGQL, and NodeDB.</dd>
       <dt>2026-06-01</dt>


### PR DESCRIPTION
Two catalogue entries (closes #55).

- **Traverse** (Truespar) — in-memory property graph database in Rust, Cypher/GQL over Bolt, proprietary.
- **Grust** (QueryGraph) — backend-neutral property graph API library for Rust, Apache-2.0.

Build passes; both render at `/db/<slug>/` and flow into api.json and the sitemap.