### PR TITLE
Add YouTrackDB

### DIFF
--- a/src/content/databases/youtrackdb.toml
+++ b/src/content/databases/youtrackdb.toml
@@ -1,0 +1,14 @@
+name = "YouTrackDB"
+vendor = "JetBrains"
+slug = "youtrackdb"
+description = "An object-oriented graph database that models data as classes with inheritance and polymorphism and resolves link traversals in O(1) without runtime joins. Forked from OrientDB by one of its former lead developers and maintained by JetBrains, it is queried with Gremlin over the TinkerPop stack and runs the same code embedded in-process or as a server."
+url = "https://youtrackdb.io"
+github_url = "https://github.com/JetBrains/youtrackdb"
+license = "Apache-2.0"
+implementation_language = "Java"
+type = "Property Graph"
+query_languages = ["Gremlin", "SQL"]
+kind = "database"
+released = "2024-02"
+category = "Emerging"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-07-14</dt>
+      <dd>Added YouTrackDB.</dd>
       <dt>2026-07-13</dt>
       <dd>Added Truespar Traverse and Grust.</dd>
       <dt>2026-06-20</dt>


### PR DESCRIPTION
Adds YouTrackDB to the catalogue — a HN-surfaced JetBrains project.

An object-oriented graph database forked from OrientDB by one of its former lead developers and maintained by JetBrains. Speaks Gremlin over the TinkerPop stack, resolves link traversals in O(1) without runtime joins, and runs the same code embedded in-process or as a server.

Fields: Property Graph (matching the existing Sones GraphDB object-oriented entry), Java, Apache-2.0, category Emerging, released 2024-02 (repo creation / fork). Changelog entry added.

`npx astro build` passes; `/db/youtrackdb/` renders.