### PR TITLE
Add NeuG, StromaDB, YugabyteDB MAGE, and RecallGraph

### DIFF
--- a/src/content/databases/neug.toml
+++ b/src/content/databases/neug.toml
@@ -1,0 +1,14 @@
+name = "NeuG"
+vendor = "Alibaba"
+slug = "neug"
+description = "An embedded property graph database for combined analytical and transactional workloads, developed by the GraphScope team at Alibaba on the GraphScope Flex engine. Runs in-process from Python or Node.js or as a network service on the same core, with Cypher queries and a DuckDB-inspired extension system for graph algorithms."
+url = "https://graphscope.io/neug/"
+github_url = "https://github.com/alibaba/neug"
+license = "Apache-2.0"
+implementation_language = "C++"
+type = "Property Graph"
+kind = "embedded"
+query_languages = ["Cypher"]
+released = "2026-03"
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/recallgraph.toml
+++ b/src/content/databases/recallgraph.toml
@@ -1,0 +1,17 @@
+name = "RecallGraph"
+vendor = "RecallGraph"
+slug = "recallgraph"
+description = "A versioned property graph store built as an ArangoDB Foxx microservice, retaining every change to vertices and edges for point-in-time traversals and diffs through a REST API. First released as CivicGraph in 2019; archived in 2026 with the Rust-based Minigraf named as its successor."
+url = "https://github.com/RecallGraph/RecallGraph"
+github_url = "https://github.com/RecallGraph/RecallGraph"
+license = "Apache-2.0"
+implementation_language = "JavaScript"
+type = "Property Graph"
+kind = "extension"
+query_languages = ["Custom API"]
+released = "2019-04"
+category = "Emerging"
+status = "deprecated"
+status_note = "Repository archived; development moved to the successor project Minigraf."
+previous_names = ["CivicGraph"]
+gdotv_support = false

--- a/src/content/databases/stromadb.toml
+++ b/src/content/databases/stromadb.toml
@@ -1,0 +1,14 @@
+name = "StromaDB"
+vendor = "Katsuhide Tsuruta"
+slug = "stromadb"
+description = "A source-available property graph engine written in Rust that combines typed edges, vector search, and bitemporal facts for retrieval-augmented generation workloads. Queried through a composable operator API over CLI, HTTP, and MCP rather than a graph query language."
+url = "https://stromadb.com/"
+github_url = "https://github.com/katsut/stromadb"
+license = "Elastic-2.0"
+implementation_language = "Rust"
+type = "Property Graph"
+kind = "database"
+query_languages = ["Custom API"]
+released = "2026-06"
+category = "Emerging"
+gdotv_support = false

--- a/src/content/databases/yugabytedb-mage.toml
+++ b/src/content/databases/yugabytedb-mage.toml
@@ -1,0 +1,14 @@
+name = "YugabyteDB MAGE"
+vendor = "Yugabyte"
+slug = "yugabytedb-mage"
+description = "A multi-tenant graph engine for YugabyteDB based on a port of Apache AGE, storing property graphs alongside relational data in the distributed PostgreSQL-compatible YSQL layer and queried with openCypher embedded in SQL. Introduced as a technical preview in YugabyteDB 2026.1 (June 2026)."
+url = "https://www.yugabyte.com/blog/a-postgresql-database-for-every-agent/"
+github_url = "https://github.com/yugabyte/yugabyte-db"
+license = "Apache-2.0"
+implementation_language = "C"
+type = "Property Graph"
+kind = "extension"
+query_languages = ["openCypher", "SQL"]
+released = "2026-06"
+category = "Emerging"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-07-19</dt>
+      <dd>Added NeuG, StromaDB, YugabyteDB MAGE, and RecallGraph.</dd>
       <dt>2026-07-14</dt>
       <dd>Added YouTrackDB.</dd>
       <dt>2026-07-13</dt>


### PR DESCRIPTION
Adds four engines from open issues:

- **NeuG** (closes #61) — embedded property graph database from the GraphScope team at Alibaba, built on GraphScope Flex; Cypher, C++, Apache-2.0, first released 2026-03.
- **StromaDB** (closes #60) — Rust property graph engine combining typed edges, vector search, and bitemporal facts for RAG workloads; composable operator API (no graph query language), Elastic-2.0, released 2026-06.
- **YugabyteDB MAGE** (closes #52) — Yugabyte's multi-tenant graph engine: Apache AGE ported into YugabyteDB and renamed `mage`; openCypher-in-SQL, technical preview in v2026.1 (June 2026). Not to be confused with Memgraph MAGE.
- **RecallGraph** (closes #62) — versioned property graph store as an ArangoDB Foxx microservice; marked `deprecated` — the repo is archived with Rust-based Minigraf named as its successor. `previous_names = ["CivicGraph"]` for its 2020 rename.

No `[features]` blocks (paper-scored engines only). Changelog updated in about.astro. `npx astro build` passes; all four `/db/<slug>/` pages build (178 pages total).