### PR TITLE
Add Minigraf

### DIFF
--- a/src/content/databases/minigraf.toml
+++ b/src/content/databases/minigraf.toml
@@ -1,0 +1,13 @@
+name = "Minigraf"
+slug = "minigraf"
+description = "An embedded, single-file graph database with Datalog queries over entity-attribute-value facts and bi-temporal time travel via per-fact transaction and valid time. Written in Rust with WebAssembly and mobile builds, targeting AI-agent memory. Successor to the archived RecallGraph."
+url = "https://github.com/project-minigraf/minigraf"
+github_url = "https://github.com/project-minigraf/minigraf"
+license = "MIT OR Apache-2.0"
+implementation_language = "Rust"
+type = "Other"
+kind = "embedded"
+query_languages = ["Datalog"]
+released = "2026-04"
+category = "Emerging"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-07-20</dt>
+      <dd>Added Minigraf.</dd>
       <dt>2026-07-19</dt>
       <dd>Added NeuG, StromaDB, YugabyteDB MAGE, and RecallGraph.</dd>
       <dt>2026-07-14</dt>


### PR DESCRIPTION
Adds Minigraf (https://github.com/project-minigraf/minigraf) to the catalogue.

An embedded, single-file graph database in Rust: Datalog queries over entity-attribute-value facts, bi-temporal semantics (per-fact transaction and valid time), WASM and mobile builds, aimed at AI-agent memory. Successor to RecallGraph (same author, Aditya Mukhopadhyay); the RecallGraph entry already names it as successor, so this closes that cross-reference.

Field notes:
- `type = "Other"` — EAV facts with Datalog is neither LPG nor RDF (TribleSpace/TypeDB precedent).
- `query_languages = ["Datalog"]` — new value; `canonicalQueryLanguage` passes unknown labels through and badge rendering falls back to an unlinked span, so no ranking-boards change needed.
- `license = "MIT OR Apache-2.0"` — repo ships both LICENSE-MIT and LICENSE-APACHE; GitHub's detector only reports the Apache half.
- `released = "2026-04"` — first crates.io release (v0.19.0, 2026-04-08). The repo was created 2023-07 with a small pre-Datalog proof of concept, then had no commits until the 2026 development sprint, and 2023 public visibility could not be verified.

Validated with `npx astro build` (179 pages, no schema errors; `dist/db/minigraf/index.html` present).