### PR TITLE
Return real 404s instead of soft 404 copies of the homepage

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,9 +1,13 @@
 # Redirects for legacy/brand-friendly URLs not in the build output.
 # Cloudflare Pages format: <source> <destination> <status>
 
-# Canonical host is the apex. Send the www custom domain to it so the two hosts
-# don't split indexing. Requires www.gdb-engines.com to be attached to this project.
-https://www.gdb-engines.com/* https://gdb-engines.com/:splat 301
+# NOTE: www -> apex cannot live here. Cloudflare Pages `_redirects` sources are
+# paths only; domain-level redirects are unsupported and silently never match.
+# The www host is redirected by a zone-level Redirect Rule instead.
+
+# Astro's sitemap integration emits an index, but crawlers and tools probe the
+# conventional /sitemap.xml. Without this it hits the 404 handler.
+/sitemap.xml        /sitemap-index.xml              301
 
 # FalkorDB's catalog slug carries its legacy Redis history (`redisgraph-falkordb`).
 # Searches for "FalkorDB" should land on its page directly.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -8,9 +8,10 @@ interface Props {
   jsonLd?: string[];
   canonical?: string;
   ogImage?: string;
+  noindex?: boolean;
 }
 const dbCount = await getDatabaseCount();
-const { title, description = `Compare ${dbCount}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings.`, jsonLd = [], canonical = 'https://gdb-engines.com/', ogImage = 'https://gdb-engines.com/og.png' } = Astro.props;
+const { title, description = `Compare ${dbCount}+ graph databases side-by-side — features, licenses, query languages, and monthly popularity rankings.`, jsonLd = [], canonical = 'https://gdb-engines.com/', ogImage = 'https://gdb-engines.com/og.png', noindex = false } = Astro.props;
 const selineToken = import.meta.env.PUBLIC_SELINE_TOKEN;
 
 const siteSchema = JSON.stringify({
@@ -37,7 +38,11 @@ const siteSchema = JSON.stringify({
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content={description} />
-    <link rel="canonical" href={canonical} />
+    {/* A noindex page has no canonical: pointing one elsewhere would claim this URL
+        is a duplicate of a page that should be indexed. */}
+    {noindex
+      ? <meta name="robots" content="noindex, follow" />
+      : <link rel="canonical" href={canonical} />}
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
     <meta property="og:type" content="website" />

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,39 @@
+---
+/**
+ * Custom 404. Cloudflare Pages only returns a real 404 status when the build
+ * output contains `404.html` — without it, unmatched paths fall back to
+ * `index.html` with a 200, turning every typo into a soft 404 duplicate of the
+ * homepage.
+ */
+import Layout from '../layouts/Layout.astro';
+import SiteHeader from '../components/SiteHeader.astro';
+import '../styles/global.css';
+---
+<Layout
+  title="Page not found — GDB-Engines"
+  description="This page does not exist. Browse the graph database comparison instead."
+  noindex
+>
+  <SiteHeader />
+  <main class="notfound-page">
+    <p class="code">404</p>
+    <h1>Page not found</h1>
+    <p>That URL isn't part of the catalog. It may have been renamed, or the engine may never have had a page here.</p>
+    <ul class="links">
+      <li><a href="/">Compare all graph databases</a></li>
+      <li><a href="/rankings/">Monthly popularity rankings</a></li>
+      <li><a href="/about/">About &amp; methodology</a></li>
+    </ul>
+    <p class="note">Think an engine is missing? <a href="https://github.com/cjlm/gdb-engines/issues" target="_blank" rel="noopener noreferrer">Open an issue</a>.</p>
+  </main>
+</Layout>
+
+<style>
+  .notfound-page { max-width: 720px; margin: 0 auto; padding: calc(var(--header-height) + 4rem) 1.25rem 3rem; line-height: 1.6; color: var(--color-text-secondary); }
+  .code { font-size: 3rem; font-weight: 600; margin: 0; color: var(--color-border); line-height: 1; }
+  h1 { font-size: 1.5rem; margin: 0.5rem 0 1rem; color: var(--color-text); }
+  .links { list-style: none; padding: 0; margin: 1.5rem 0; }
+  .links li { margin-bottom: 0.5rem; }
+  .links a { color: var(--color-text); font-weight: 500; }
+  .note { font-size: 0.9rem; margin-top: 2rem; }
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -6,7 +6,7 @@ const pageJsonLd = JSON.stringify({
   "@context": "https://schema.org",
   "@type": "WebPage",
   "name": "About GDB-Engines",
-  "url": "https://gdb-engines.com/about",
+  "url": "https://gdb-engines.com/about/",
 });
 // Separate BreadcrumbList block (Google prefers this over an inline breadcrumb property).
 const breadcrumbJsonLd = JSON.stringify({


### PR DESCRIPTION
Google Search Console flagged 115 URLs under "Page with redirect". Investigating that report surfaced a separate, real problem: the site had no 404 page.

## What was wrong

Cloudflare Pages falls back to `index.html` with a **200** when the build output contains no `404.html`. Every unmatched path — typos, dead inbound links, crawler probes — returned a full copy of the homepage, including `<link rel="canonical" href="https://gdb-engines.com/">`. `https://gdb-engines.com/sitemap.xml` and `https://gdb-engines.com/db/does-not-exist/` both returned 200 with homepage HTML.

The `www` → apex rule in `public/_redirects` also never matched. Cloudflare Pages `_redirects` sources are paths only; [domain-level redirects are unsupported](https://developers.cloudflare.com/pages/configuration/redirects/). `https://www.gdb-engines.com/` serves the whole site at 200.

## Changes

- **`src/pages/404.astro`** — Astro special-cases this to `dist/404.html`, which Pages serves with a real 404 status.
- **`src/layouts/Layout.astro`** — new `noindex` prop emitting `<meta name="robots" content="noindex, follow">` in place of the canonical. A noindex page with a canonical pointing elsewhere claims to be a duplicate of an indexable page.
- **`public/_redirects`** — `/sitemap.xml` → `/sitemap-index.xml` (301) for crawlers probing the conventional path. Removed the dead `www` rule and noted where it belongs.
- **`src/pages/about.astro`** — WebPage JSON-LD `url` now carries the trailing slash, matching its own canonical and BreadcrumbList.

## Verification

Run against `wrangler pages dev dist`, which uses the real Pages runtime:

| Path | Before | After |
|---|---|---|
| `/db/does-not-exist/` | 200 (homepage) | 404 |
| `/totally-bogus` | 200 (homepage) | 404 |
| `/sitemap.xml` | 200 (homepage HTML) | 301 → `/sitemap-index.xml` (200, XML) |
| `/db/falkordb/` | 301 → `/db/redisgraph-falkordb/` | unchanged |
| `/db/neo4j/`, `/`, `/about/` | 200 | 200 |

`dist/404.html` carries `noindex` and no canonical, and is excluded from the sitemap. Canonicals on `/`, `/about/`, `/db/neo4j/`, `/rankings/`, `/sponsor/` are unchanged. No shipped HTML or JSON-LD advertises a no-slash internal URL.

## Not in this PR

The `www` → apex redirect needs a zone-level Redirect Rule in Cloudflare; it cannot be expressed in `_redirects`.

The 115 GSC "Page with redirect" URLs are all non-slash paths 308ing to their canonical trailing-slash form, plus the two `http://` → `https://` hops. Those redirects are correct and permanent, so that validation cannot pass and needs no code change.
