### PR TITLE
Add TypeGraph

### DIFF
--- a/src/content/databases/typegraph.toml
+++ b/src/content/databases/typegraph.toml
@@ -1,0 +1,14 @@
+name = "TypeGraph"
+vendor = "Nicia AI"
+slug = "typegraph"
+description = "An embedded graph library for TypeScript applications that keeps property graph data in an existing SQLite or PostgreSQL database, compiling typed traversals to SQL rather than running a separate graph service. Node and edge schemas are declared with Zod and carry ontology relations such as subClassOf and inverseOf, alongside vector and keyword search through pgvector, sqlite-vec, and libSQL."
+url = "https://typegraph.dev"
+github_url = "https://github.com/nicia-ai/typegraph"
+license = "MIT"
+implementation_language = "TypeScript"
+type = "Property Graph"
+kind = "library"
+query_languages = ["Custom API"]
+released = "2026-02"
+category = "Emerging"
+gdotv_support = false

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -63,6 +63,8 @@ const breadcrumbJsonLd = JSON.stringify({
 
     <h2>Changelog</h2>
     <dl class="changelog">
+      <dt>2026-07-30</dt>
+      <dd>Added TypeGraph.</dd>
       <dt>2026-07-20</dt>
       <dd>Added Minigraf.</dd>
       <dt>2026-07-19</dt>


### PR DESCRIPTION
Adds TypeGraph (https://typegraph.dev) to the catalogue, from issue #65.

A TypeScript embedded graph library that stores property graph data in an existing SQLite or PostgreSQL database and compiles typed traversals to SQL, rather than running a separate graph service. Zod-declared node and edge schemas, ontology relations (`subClassOf`, `implies`, `inverseOf`, `disjointWith`), and hybrid vector/keyword search across pgvector, sqlite-vec, and libSQL.

Field notes:
- `kind = "library"` — its own docs are explicit: "TypeGraph is an embedded library, not a database" and "a library dependency, not a networked service". It never owns storage, so `embedded` (an in-process DB, SQLite-style) would overstate it.
- `type = "Property Graph"` — nodes and edges with properties. The ontology relations add semantics but there are no triples and no SPARQL, so not `RDF`.
- `query_languages = ["Custom API"]` — fluent TypeScript query builder, no standard language.
- `released = "2026-02"` — repo created and npm `0.1.0` published 2026-02-08, same day.
- `license = "MIT"` — confirmed on both the repo and the npm package.
- `vendor = "Nicia AI"` — from the `@nicia-ai` npm scope and GitHub org.

Currently at `0.45.0` (2026-07-29), 71 stars, pushed today. 57 releases in under six months.

Validated with `npm run build` (181 pages, no schema errors; `dist/db/typegraph/index.html` present).
