### PR TITLE
Cut competing ranking boards

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -9,11 +9,36 @@
 # conventional /sitemap.xml. Without this it hits the 404 handler.
 /sitemap.xml        /sitemap-index.xml              301
 
-# The library board was retired (zero Search Console impressions over 90 days).
-# Cloudflare Pages evaluates _redirects before static assets, so this entry can only
-# be added once the board itself stops being generated.
+# Retired ranking boards. Safe to list here only because the same commit stops
+# generating them — Cloudflare Pages evaluates _redirects before static assets, so an
+# entry for a live path would shadow the page.
+# Language boards below the ten-engine floor:
+/rankings/go                /rankings/                      301
+/rankings/go/               /rankings/                      301
+/rankings/csharp            /rankings/                      301
+/rankings/csharp/           /rankings/                      301
+/rankings/typescript        /rankings/                      301
+/rankings/typescript/       /rankings/                      301
+/rankings/python            /rankings/                      301
+/rankings/python/           /rankings/                      301
+/rankings/scala             /rankings/                      301
+/rankings/scala/            /rankings/                      301
+# Kind boards below the floor:
 /rankings/graph-library     /rankings/                      301
 /rankings/graph-library/    /rankings/                      301
+/rankings/graph-extension   /rankings/                      301
+/rankings/graph-extension/  /rankings/                      301
+/rankings/graph-query-engine   /rankings/                   301
+/rankings/graph-query-engine/  /rankings/                   301
+# Retired license group:
+/rankings/copyleft          /rankings/                      301
+/rankings/copyleft/         /rankings/                      301
+/rankings/permissive-licensed   /rankings/                  301
+/rankings/permissive-licensed/  /rankings/                  301
+/rankings/proprietary       /rankings/                      301
+/rankings/proprietary/      /rankings/                      301
+/rankings/source-available  /rankings/                      301
+/rankings/source-available/ /rankings/                      301
 
 # FalkorDB's catalog slug carries its legacy Redis history (`redisgraph-falkordb`).
 # Searches for "FalkorDB" should land on its page directly.

--- a/public/_redirects
+++ b/public/_redirects
@@ -9,6 +9,12 @@
 # conventional /sitemap.xml. Without this it hits the 404 handler.
 /sitemap.xml        /sitemap-index.xml              301
 
+# The library board was retired (zero Search Console impressions over 90 days).
+# Cloudflare Pages evaluates _redirects before static assets, so this entry can only
+# be added once the board itself stops being generated.
+/rankings/graph-library     /rankings/                      301
+/rankings/graph-library/    /rankings/                      301
+
 # FalkorDB's catalog slug carries its legacy Redis history (`redisgraph-falkordb`).
 # Searches for "FalkorDB" should land on its page directly.
 /db/falkordb        /db/redisgraph-falkordb/        301

--- a/public/_redirects
+++ b/public/_redirects
@@ -12,7 +12,9 @@
 # Retired ranking boards. Safe to list here only because the same commit stops
 # generating them — Cloudflare Pages evaluates _redirects before static assets, so an
 # entry for a live path would shadow the page.
-# Language boards below the ten-engine floor:
+# Language boards below the fifteen-engine floor:
+/rankings/c                 /rankings/                      301
+/rankings/c/                /rankings/                      301
 /rankings/go                /rankings/                      301
 /rankings/go/               /rankings/                      301
 /rankings/csharp            /rankings/                      301

--- a/src/lib/ranking-boards.ts
+++ b/src/lib/ranking-boards.ts
@@ -43,8 +43,10 @@ export const slugify = (s: string): string =>
 
 // Boards we omit on purpose:
 //   - byKind.database overlaps almost entirely with the overall board
-//   - byImplementationLanguage groups with <3 engines (already filtered upstream)
-const SKIP_KIND = new Set(['database']);
+//   - byKind.library ranks a toolkit set nobody searches as a ranking (90 days of
+//     Search Console to 2026-07-29: zero impressions, zero clicks)
+//   - byImplementationLanguage groups below the upstream MIN_LANGUAGE_ENGINES floor
+const SKIP_KIND = new Set(['database', 'library']);
 
 // type 'Other' and license-tier 'Other' would both want the slug "other"; relabel the
 // license one as "Source-Available" since after the recent metadata fixes it's mostly BSL.
@@ -252,8 +254,8 @@ export function buildBoards(ranking: RankingFile): Board[] {
       title: gdbRankingTitle(lang),
       h1: gdbRankingTitle(lang),
       shortLabel: lang,
-      blurb: `The best and most popular graph databases written in ${lang}, ranked monthly across adoption, activity, community and research signals. Compare top ${lang} graph database options.`,
-      metaDescription: `The best and most popular graph databases written in ${lang}, ranked monthly. Compare top ${lang} graph database options.`,
+      blurb: `Graph databases implemented in ${lang}, ranked monthly across adoption, activity, community and research signals.`,
+      metaDescription: `Graph databases implemented in ${lang}, ranked monthly across adoption, activity, community and research signals.`,
       group: 'language',
     }, engines));
   }

--- a/src/lib/ranking-boards.ts
+++ b/src/lib/ranking-boards.ts
@@ -197,10 +197,17 @@ function gdbRankingTitle(label: string): string {
   return `${trimmed} Graph Databases, Ranked Monthly`;
 }
 
-// A board needs enough engines for the ordering to mean anything. Query language is
-// the exception: it is how people shop for an engine, and it carries the best-performing
-// board on the site, so emerging standards stay in below the floor.
-const MIN_BOARD_ENGINES = 10;
+// A board needs enough engines for the ordering to mean anything. Set at 15 on the
+// evidence rather than by feel: C (10 engines) drew 393 impressions across 52 queries
+// in the 90 days to 2026-07-29 and not one was about C — they were "best graph
+// database", "top graph databases", "db engines ranking", all at position 43-91. It had
+// become the site's generic-head-term page, competing with /rankings/overall/ and
+// winning nothing. Rust (19) is the smallest board that actually wins its own queries
+// ("rust graph database", "graph database rust", positions 9-12).
+//
+// Query language is exempt: it is how people shop for an engine, and it carries the
+// best-performing board on the site, so emerging standards stay in below the floor.
+const MIN_BOARD_ENGINES = 15;
 
 export function buildBoards(ranking: RankingFile): Board[] {
   const boards: Board[] = [];

--- a/src/lib/ranking-boards.ts
+++ b/src/lib/ranking-boards.ts
@@ -1,7 +1,7 @@
 /**
  * Turns a RankingFile into the flat list of pages to generate. Each board becomes a page at
- * /rankings/{slug}. Titles use the "X Graph Database Popularity Ranking" convention; meta
- * descriptions include "best / most popular / top" for long-tail SEO.
+ * /rankings/{slug}. Only /rankings/overall/ targets the generic head terms; sub-boards lead
+ * with their qualifier so they stop competing with it, and with each other.
  */
 import type { RankingFile, RankedEngine } from './rankings';
 
@@ -72,7 +72,7 @@ const KIND_LABEL: Record<string, string> = {
 };
 
 const blurbFor = (label: string): string =>
-  `The most popular ${label.toLowerCase()} graph databases, ranked monthly by adoption, activity, community and research signals.`;
+  `${label} graph databases, ranked monthly by adoption, activity, community and research signals.`;
 
 const blurbOverall =
   'The most popular graph databases, ranked monthly across adoption, activity, community and research signals.';
@@ -110,23 +110,32 @@ export function buildLinkMaps(ranking: RankingFile): {
   overallRank: Map<string, number>;
   overallDelta1m: Map<string, number | 'new' | null>;
 } {
-  const typeSlug = new Map<string, string>();
-  for (const k of Object.keys(ranking.byType)) typeSlug.set(k, slugify(TYPE_LABEL[k] ?? k));
-  const kindSlug = new Map<string, string>();
-  for (const k of Object.keys(ranking.byKind)) {
-    if (SKIP_KIND.has(k)) continue;
-    kindSlug.set(k, slugify(KIND_LABEL[k] ?? k));
-  }
-  const licenseTierSlugMap = new Map<string, string>();
-  for (const k of Object.keys(ranking.byLicenseTier)) licenseTierSlugMap.set(k, slugify(LICENSE_LABEL[k] ?? k));
+  // Only link to boards that survive the group and size gates in buildBoards, so a
+  // retired board never leaves a dangling /rankings/<slug>/ link behind on a value.
+  const live = new Set(buildBoards(ranking).map((b) => b.slug));
+  const linkable = (label: string): string | null => {
+    const slug = slugify(label);
+    return live.has(slug) ? slug : null;
+  };
+  const mapFor = (keys: string[], label: (k: string) => string): Map<string, string> => {
+    const out = new Map<string, string>();
+    for (const k of keys) {
+      const slug = linkable(label(k));
+      if (slug) out.set(k, slug);
+    }
+    return out;
+  };
+  const typeSlug = mapFor(Object.keys(ranking.byType), (k) => TYPE_LABEL[k] ?? k);
+  const kindSlug = mapFor(
+    Object.keys(ranking.byKind).filter((k) => !SKIP_KIND.has(k)),
+    (k) => KIND_LABEL[k] ?? k
+  );
   const licenseTierSlug = (spdx: string | null | undefined): string | null => {
     const tier = licenseTierLabel(spdx);
-    return licenseTierSlugMap.get(tier) ?? null;
+    return linkable(LICENSE_LABEL[tier] ?? tier);
   };
-  const queryLanguageSlug = new Map<string, string>();
-  for (const k of Object.keys(ranking.byQueryLanguage)) queryLanguageSlug.set(k, slugify(k));
-  const implementationLanguageSlug = new Map<string, string>();
-  for (const k of Object.keys(ranking.byImplementationLanguage)) implementationLanguageSlug.set(k, slugify(k));
+  const queryLanguageSlug = mapFor(Object.keys(ranking.byQueryLanguage), (k) => k);
+  const implementationLanguageSlug = mapFor(Object.keys(ranking.byImplementationLanguage), (k) => k);
   const overallRank = new Map<string, number>();
   const overallDelta1m = new Map<string, number | 'new' | null>();
   // Rank among engines that actually appear on the public board (Insufficient stripped).
@@ -178,10 +187,20 @@ function makeBoard(meta: BoardMeta, engines: RankedEngine[]): Board {
 
 // Build "{label} Graph Database Popularity Ranking", avoiding the duplicate-word
 // "Property Graph Graph Database" when the label already ends in "Graph".
+//
+// Sub-boards lead with their qualifier and end "Ranked Monthly" rather than
+// repeating "Graph Database Popularity Ranking", which 30 pages were bidding for
+// against /rankings/overall/. Search Console showed nine of them splitting the
+// impressions for "graph database ranking" while overall (position 4) got two.
 function gdbRankingTitle(label: string): string {
   const trimmed = label.endsWith(' Graph') ? label.slice(0, -' Graph'.length) : label;
-  return `${trimmed} Graph Database Popularity Ranking`;
+  return `${trimmed} Graph Databases, Ranked Monthly`;
 }
+
+// A board needs enough engines for the ordering to mean anything. Query language is
+// the exception: it is how people shop for an engine, and it carries the best-performing
+// board on the site, so emerging standards stay in below the floor.
+const MIN_BOARD_ENGINES = 10;
 
 export function buildBoards(ranking: RankingFile): Board[] {
   const boards: Board[] = [];
@@ -223,18 +242,10 @@ export function buildBoards(ranking: RankingFile): Board[] {
     }, engines));
   }
 
-  for (const [tier, engines] of Object.entries(ranking.byLicenseTier)) {
-    const label = LICENSE_LABEL[tier] ?? tier;
-    boards.push(makeBoard({
-      slug: slugify(label),
-      title: gdbRankingTitle(label),
-      h1: gdbRankingTitle(label),
-      shortLabel: label,
-      blurb: blurbFor(label),
-      metaDescription: blurbFor(label),
-      group: 'license',
-    }, engines));
-  }
+  // The license group is retired: four boards, 71 impressions and zero clicks over the
+  // 90 days to 2026-07-29. Ranking 71 of 143 engines by "permissive licence" was never a
+  // question anyone asked, and the pages competed with the overall board for head terms.
+  // License remains a sortable column on the homepage.
 
   for (const [lang, engines] of Object.entries(ranking.byQueryLanguage)) {
     boards.push(makeBoard({
@@ -273,11 +284,13 @@ export function buildBoards(ranking: RankingFile): Board[] {
   // De-duplicate any accidental slug collisions across categories (last wins isn't ideal —
   // but with our current label maps there shouldn't be any).
   const seen = new Set<string>();
+  const exemptFromFloor = new Set(['overall', 'movers', 'query-language']);
   return boards.filter((b) => {
     if (seen.has(b.slug)) {
       console.warn(`[rankings] dropping board with duplicate slug "${b.slug}" (group=${b.group})`);
       return false;
     }
+    if (!exemptFromFloor.has(b.group) && b.engines.length < MIN_BOARD_ENGINES) return false;
     seen.add(b.slug);
     return true;
   });


### PR DESCRIPTION
Cuts the ranking boards that were competing with `/rankings/overall/` for the same queries, and stops the survivors doing it.

Search Console, 90 days to 2026-07-29: nine boards split the impressions for "graph database ranking" while `/rankings/overall/` sat at position 4 with two. Seven competed for "best graph database", none above position 33.

**Boards 31 → 18.** Retired:
- Six implementation-language boards under a fifteen-engine floor. Includes C, whose 393 impressions across 52 queries contained **not one C-related search** — they were "best graph database", "top graph databases", "db engines ranking", all at position 43-91. It had become the generic-head-term page. Rust (19) is the smallest board that wins its own queries.
- `library`, `extension`, `query-engine` — same floor.
- The whole license group: 71 impressions, 0 clicks. License stays a sortable column on the homepage.

Query-language boards are exempt from the floor: it's the axis people shop on and it holds the best board by clicks (GQL). SQL/PGQ survives at 6.

**Titles and blurbs.** Sub-boards read `Rust Graph Databases, Ranked Monthly` instead of `Rust Graph Database Popularity Ranking`, and the shared blurb drops "The best and most popular…". Only the overall board targets the head term.

**Links.** `buildLinkMaps` is gated on surviving boards so a retired board can't leave a dangling link on a badge. No page links to any of the 13 retired slugs; all get 301s to `/rankings/`.

Build clean, 167 pages.
