### PR TITLE
Add interactive graph database map

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,8 @@ import { execSync } from 'node:child_process';
 
 // Fallback for pages whose real change date can't be derived from git.
 const buildDate = new Date().toISOString().split('T')[0];
+const garphieldOrigin =
+  process.env.PUBLIC_GARPHIELD_ORIGIN ?? 'https://garphield.com';
 
 /** Last git commit date (YYYY-MM-DD) touching any of `paths`, or null if unavailable. */
 function gitDate(...paths) {
@@ -52,6 +54,17 @@ export default defineConfig({
   // Canonical URLs carry a trailing slash (directory build format). Enforce it
   // so a no-slash internal link is a build error, not a silent 301 redirect.
   trailingSlash: 'always',
+  // Sigma loads node images into a WebGL texture atlas with anonymous CORS.
+  // Production mirrors these headers in public/_headers; this keeps local
+  // GDB + local Garphield development working with the same generated docs.
+  vite: {
+    server: {
+      headers: {
+        'Access-Control-Allow-Origin': garphieldOrigin,
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+      },
+    },
+  },
   integrations: [
     sitemap({
       // /compare/custom/ is noindex; listing a noindex URL in a sitemap is a

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@astrojs/sitemap": "^3.7.1",
         "astro": "^5.17.1",
         "astro-og-canvas": "^0.11.1",
-        "canvaskit-wasm": "^0.41.1"
+        "canvaskit-wasm": "^0.41.1",
+        "garphield": "0.1.1"
       }
     },
     "node_modules/@11ty/eleventy-fetch": {
@@ -2352,6 +2353,12 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/garphield": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/garphield/-/garphield-0.1.1.tgz",
+      "integrity": "sha512-LDlGKWHMAtvrvb38NQ/YnocQh36UFBquVvfZ8hb+pbMajeOqDZk7IT899kOjXIyWg67w7DB8lpyqpRadI1c31A==",
+      "license": "MIT"
     },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -3,10 +3,11 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "favicons": "node scripts/extract-favicons.mjs",
     "graphs": "node scripts/generate-graphs.mjs",
-    "predev": "npm run graphs",
+    "predev": "npm run favicons && npm run graphs",
     "dev": "astro dev",
-    "prebuild": "node scripts/extract-favicons.mjs && npm run graphs",
+    "prebuild": "npm run favicons && npm run graphs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "graphs": "node scripts/generate-graphs.mjs",
+    "predev": "npm run graphs",
     "dev": "astro dev",
-    "prebuild": "node scripts/extract-favicons.mjs",
+    "prebuild": "node scripts/extract-favicons.mjs && npm run graphs",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro"
@@ -14,6 +16,7 @@
     "@astrojs/sitemap": "^3.7.1",
     "astro": "^5.17.1",
     "astro-og-canvas": "^0.11.1",
-    "canvaskit-wasm": "^0.41.1"
+    "canvaskit-wasm": "^0.41.1",
+    "garphield": "0.1.1"
   }
 }

--- a/public/_headers
+++ b/public/_headers
@@ -4,7 +4,11 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://sln.gdb-engines.com; connect-src 'self' https://sln.gdb-engines.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-ancestors 'none'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://sln.gdb-engines.com; connect-src 'self' https://sln.gdb-engines.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self'; frame-src https://garphield.com; frame-ancestors 'none'
+
+/graphs/*
+  Access-Control-Allow-Origin: https://garphield.com
+  Cache-Control: public, max-age=3600
 
 # Content-hashed Astro bundles never change at the same URL — long-cache.
 /_astro/*

--- a/public/_headers
+++ b/public/_headers
@@ -10,6 +10,11 @@
   Access-Control-Allow-Origin: https://garphield.com
   Cache-Control: public, max-age=3600
 
+/logos/*
+  Access-Control-Allow-Origin: https://garphield.com
+  Cross-Origin-Resource-Policy: cross-origin
+  Cache-Control: public, max-age=86400
+
 # Content-hashed Astro bundles never change at the same URL — long-cache.
 /_astro/*
   Cache-Control: public, max-age=31536000, immutable

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -1,0 +1,2436 @@
+{
+  "info": {
+    "version": 1,
+    "name": "Databases × query languages"
+  },
+  "datasets": [
+    {
+      "id": "main",
+      "graph": {
+        "directed": false,
+        "multigraph": false,
+        "graph": {
+          "name": "Databases × query languages"
+        },
+        "nodes": [
+          {
+            "id": "db:4store",
+            "label": "4store",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:aerospike",
+            "label": "Aerospike Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:agdb",
+            "label": "agdb",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:agensgraph",
+            "label": "AgensGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:akutan",
+            "label": "Akutan",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:alibaba-gdb",
+            "label": "Alibaba GDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:allegrograph",
+            "label": "AllegroGraph",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:altair-graph-lakehouse",
+            "label": "Altair Graph Lakehouse",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:apache-age",
+            "label": "Apache AGE",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:apache-giraph",
+            "label": "Apache Giraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "inactive"
+          },
+          {
+            "id": "db:apache-hugegraph",
+            "label": "Apache HugeGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:apache-jena-fuseki",
+            "label": "Apache Jena Fuseki",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:apache-rya",
+            "label": "Apache Rya",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:arangodb",
+            "label": "ArangoDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:arcadedb",
+            "label": "ArcadeDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:atomic-server",
+            "label": "Atomic Server",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:attean",
+            "label": "Attean",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:bangdb",
+            "label": "BangDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:bighorn",
+            "label": "Bighorn",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:bigquery-graph",
+            "label": "Google Cloud BigQuery Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:bitsy",
+            "label": "Bitsy",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:blazegraph",
+            "label": "BlazeGraph",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "inactive"
+          },
+          {
+            "id": "db:brightstardb",
+            "label": "BrightstarDB",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:bytegraph",
+            "label": "ByteGraph",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Enterprise",
+            "status": "inactive"
+          },
+          {
+            "id": "db:chronograph",
+            "label": "ChronoGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:codemix-graph",
+            "label": "CodeMix Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:cogdb",
+            "label": "CogDB",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:comunica",
+            "label": "Comunica",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:cosmos-db",
+            "label": "Cosmos DB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:cray-graph-engine",
+            "label": "Cray Graph Engine",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Enterprise",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:data-graphs",
+            "label": "Data Graphs",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:datastax-enterprise",
+            "label": "DataStax Enterprise",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:dgraph",
+            "label": "Dgraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:dozerdb",
+            "label": "DozerDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:duckpgq",
+            "label": "DuckPGQ",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:dydra",
+            "label": "Dydra",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:eclipse-rdf4j",
+            "label": "Eclipse RDF4J",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:fabric-graph",
+            "label": "Microsoft Fabric Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:falkordblite",
+            "label": "FalkorDBLite",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:faunadb",
+            "label": "FaunaDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:flockdb",
+            "label": "FlockDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Established",
+            "status": "inactive"
+          },
+          {
+            "id": "db:fluree",
+            "label": "Fluree",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:frogql",
+            "label": "froGQL",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:g-tran",
+            "label": "G-Tran",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:gaffer",
+            "label": "Gaffer",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:galaxybase",
+            "label": "GalaxyBase",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:gfql",
+            "label": "GFQL",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:google-cayley",
+            "label": "Google Cayley",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:grafeo",
+            "label": "Grafeo",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:graph-engine",
+            "label": "Graph Engine",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "inactive"
+          },
+          {
+            "id": "db:graphbase",
+            "label": "GraphBase",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:graphflow",
+            "label": "Graphflow",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:graphlite",
+            "label": "GraphLite",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:graphqlite",
+            "label": "GraphQLite",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:graphscope",
+            "label": "GraphScope",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:grust",
+            "label": "Grust",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:gstore",
+            "label": "gStore",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:gun",
+            "label": "GUN",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:halyard",
+            "label": "Halyard",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:helixdb",
+            "label": "HelixDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:hgraphdb",
+            "label": "HGraphDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:huawei-ges",
+            "label": "Huawei Graph Engine Service",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:hypergraphdb",
+            "label": "HyperGraphDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:ibm-system-g",
+            "label": "IBM System G",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Enterprise",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:infinitegraph",
+            "label": "InfiniteGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "inactive"
+          },
+          {
+            "id": "db:janusgraph",
+            "label": "JanusGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:katanagraph",
+            "label": "KatanaGraph",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:kglite",
+            "label": "KGLite",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:kinetica",
+            "label": "Kinetica",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:kuzu",
+            "label": "Kuzu",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:ladybugdb",
+            "label": "LadybugDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:lance-graph",
+            "label": "Lance Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:livegraph",
+            "label": "LiveGraph",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:marklogic",
+            "label": "MarkLogic",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:marmotta-kiwi",
+            "label": "Apache Marmotta KiWi",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:memgql",
+            "label": "MemGQL",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:memgraph",
+            "label": "Memgraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:millenniumdb",
+            "label": "MillenniumDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:minigraf",
+            "label": "Minigraf",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:mulgara",
+            "label": "Mulgara",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:nebulagraph",
+            "label": "NebulaGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:neo4j",
+            "label": "Neo4j",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:neptune",
+            "label": "Neptune",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:neug",
+            "label": "NeuG",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:nodedb",
+            "label": "NodeDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:nornicdb",
+            "label": "NornicDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:objectivity-db",
+            "label": "Objectivity/DB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Enterprise",
+            "status": "inactive"
+          },
+          {
+            "id": "db:omnigraph",
+            "label": "OmniGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:ongdb",
+            "label": "ONgDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:ontop",
+            "label": "Ontop",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:ontotext-graphdb",
+            "label": "Ontotext GraphDB",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:oracle-graph",
+            "label": "Oracle Graph",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:orientdb",
+            "label": "OrientDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:oxigraph",
+            "label": "Oxigraph",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:oxirs",
+            "label": "OxiRS",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:pandadb",
+            "label": "PandaDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:parliament",
+            "label": "Parliament",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:pggraph",
+            "label": "pgGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:postgresql-sql-pgq",
+            "label": "PostgreSQL SQL/PGQ",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:prometheux",
+            "label": "Prometheux",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:puppygraph",
+            "label": "PuppyGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:qlever",
+            "label": "QLever",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:quadstore",
+            "label": "Quadstore",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:quine",
+            "label": "Quine",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:raphtory",
+            "label": "Raphtory",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:rdf-trine",
+            "label": "RDF::Trine",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:rdflib",
+            "label": "RDFLib",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:rdfox",
+            "label": "RDFox",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:recallgraph",
+            "label": "RecallGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "deprecated"
+          },
+          {
+            "id": "db:redisgraph-falkordb",
+            "label": "FalkorDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:redland",
+            "label": "Redland",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Established",
+            "status": "inactive"
+          },
+          {
+            "id": "db:redstore",
+            "label": "RedStore",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:relationalai",
+            "label": "RelationalAI",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:rocketgraph",
+            "label": "Rocketgraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:rushdb",
+            "label": "RushDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:ryugraph",
+            "label": "RyuGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:sap-hana",
+            "label": "SAP Hana",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:sones-graphdb",
+            "label": "Sones GraphDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:spanner-graph",
+            "label": "Google Cloud Spanner Graph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:sparkledb",
+            "label": "SparkleDB",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:sparksee",
+            "label": "Sparksee",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:stardog",
+            "label": "Stardog",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:stellardb",
+            "label": "StellarDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:strabon",
+            "label": "Strabon",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:stromadb",
+            "label": "StromaDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:surrealdb",
+            "label": "SurrealDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:tao",
+            "label": "TAO",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:tentris",
+            "label": "Tentris",
+            "kind": "Database",
+            "type": "RDF",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:terminusdb",
+            "label": "TerminusDB",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:tigergraph",
+            "label": "TigerGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:tinkergraph",
+            "label": "TinkerGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:traverse",
+            "label": "Traverse",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:triblespace",
+            "label": "TribleSpace",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:tugraph",
+            "label": "TuGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Established",
+            "status": "active"
+          },
+          {
+            "id": "db:turbolynx",
+            "label": "TurboLynx",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:turingdb",
+            "label": "TuringDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:typedb",
+            "label": "TypeDB",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:ultipa",
+            "label": "Ultipa",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Growing",
+            "status": "active"
+          },
+          {
+            "id": "db:velocitygraph",
+            "label": "VelocityGraph",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:virtuoso",
+            "label": "Virtuoso",
+            "kind": "Database",
+            "type": "Multiple",
+            "category": "Enterprise",
+            "status": "active"
+          },
+          {
+            "id": "db:weaver",
+            "label": "Weaver",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "db:youtrackdb",
+            "label": "YouTrackDB",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:yugabytedb-mage",
+            "label": "YugabyteDB MAGE",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
+            "id": "db:zipg",
+            "label": "ZipG",
+            "kind": "Database",
+            "type": "Other",
+            "category": "Emerging",
+            "status": "inactive"
+          },
+          {
+            "id": "language:AQL",
+            "label": "AQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:CQL",
+            "label": "CQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Custom API",
+            "label": "Custom API",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Cypher",
+            "label": "Cypher",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:DO Query Language",
+            "label": "DO Query Language",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:DQL",
+            "label": "DQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Datalog",
+            "label": "Datalog",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:FQL",
+            "label": "FQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:FlureeQL",
+            "label": "FlureeQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GFQL",
+            "label": "GFQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GQL",
+            "label": "GQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GQL (Sones)",
+            "label": "GQL (Sones)",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GSQL",
+            "label": "GSQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GeoSPARQL",
+            "label": "GeoSPARQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Gizmo",
+            "label": "Gizmo",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GraphQL",
+            "label": "GraphQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:GraphScript",
+            "label": "GraphScript",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Gremlin",
+            "label": "Gremlin",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:HelixQL",
+            "label": "HelixQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Java API",
+            "label": "Java API",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:LIKQ",
+            "label": "LIKQ",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:LINQ",
+            "label": "LINQ",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:MQL",
+            "label": "MQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:PGQL",
+            "label": "PGQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Prolog",
+            "label": "Prolog",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Rel",
+            "label": "Rel",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:SPARQL",
+            "label": "SPARQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:SQL",
+            "label": "SQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:SQL/PGQ",
+            "label": "SQL/PGQ",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:SurrealQL",
+            "label": "SurrealQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:TAO API",
+            "label": "TAO API",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Thrift API",
+            "label": "Thrift API",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:TypeQL",
+            "label": "TypeQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:UQL",
+            "label": "UQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:Vadalog",
+            "label": "Vadalog",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:WOQL",
+            "label": "WOQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:XQuery",
+            "label": "XQuery",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:iTQL",
+            "label": "iTQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:nGQL",
+            "label": "nGQL",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:openCypher",
+            "label": "openCypher",
+            "kind": "Query language"
+          },
+          {
+            "id": "language:stSPARQL",
+            "label": "stSPARQL",
+            "kind": "Query language"
+          }
+        ],
+        "links": [
+          {
+            "source": "db:4store",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:aerospike",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:agdb",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:agensgraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:agensgraph",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:akutan",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:allegrograph",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:allegrograph",
+            "target": "language:Prolog",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-age",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-age",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-giraph",
+            "target": "language:Java API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:arangodb",
+            "target": "language:AQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:attean",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bangdb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bighorn",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bigquery-graph",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bigquery-graph",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bitsy",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:blazegraph",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:blazegraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "language:LINQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:chronograph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:codemix-graph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:codemix-graph",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:cogdb",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:comunica",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:comunica",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:datastax-enterprise",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:datastax-enterprise",
+            "target": "language:CQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:dgraph",
+            "target": "language:DQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:dgraph",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:dozerdb",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:duckpgq",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:dydra",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:dydra",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:eclipse-rdf4j",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:falkordblite",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:faunadb",
+            "target": "language:FQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:faunadb",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:flockdb",
+            "target": "language:Thrift API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:fluree",
+            "target": "language:FlureeQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:fluree",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:fluree",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:frogql",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:g-tran",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:gaffer",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:gfql",
+            "target": "language:GFQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:gfql",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:google-cayley",
+            "target": "language:Gizmo",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:google-cayley",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:google-cayley",
+            "target": "language:MQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grafeo",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graph-engine",
+            "target": "language:LIKQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphbase",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphflow",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphlite",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphqlite",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphscope",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:graphscope",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:grust",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:gstore",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:gun",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:halyard",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:helixdb",
+            "target": "language:HelixQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:hgraphdb",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:huawei-ges",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:huawei-ges",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:hypergraphdb",
+            "target": "language:Java API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ibm-system-g",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:infinitegraph",
+            "target": "language:DO Query Language",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:janusgraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:katanagraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:kglite",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:kglite",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:kinetica",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:kuzu",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ladybugdb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:lance-graph",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:lance-graph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:livegraph",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:marklogic",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:marklogic",
+            "target": "language:XQuery",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:marklogic",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:marmotta-kiwi",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:memgql",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:memgraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:millenniumdb",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:millenniumdb",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:minigraf",
+            "target": "language:Datalog",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:mulgara",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:mulgara",
+            "target": "language:iTQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:nebulagraph",
+            "target": "language:nGQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neo4j",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neo4j",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neptune",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neptune",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neptune",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:neug",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:nodedb",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:nodedb",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:nornicdb",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:nornicdb",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:objectivity-db",
+            "target": "language:DO Query Language",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:omnigraph",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ongdb",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ontop",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ontotext-graphdb",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:oracle-graph",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:oracle-graph",
+            "target": "language:PGQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:oracle-graph",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:orientdb",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:orientdb",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:oxigraph",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:oxirs",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:pandadb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:parliament",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:pggraph",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:postgresql-sql-pgq",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:prometheux",
+            "target": "language:Vadalog",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:puppygraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:puppygraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:qlever",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:quadstore",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:quine",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:quine",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:raphtory",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:rdf-trine",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:rdflib",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:rdfox",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:recallgraph",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:redisgraph-falkordb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:redland",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:redstore",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:relationalai",
+            "target": "language:Rel",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:relationalai",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:rocketgraph",
+            "target": "language:Cypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:rushdb",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ryugraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sap-hana",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sap-hana",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sap-hana",
+            "target": "language:GraphScript",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sones-graphdb",
+            "target": "language:GQL (Sones)",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:spanner-graph",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:spanner-graph",
+            "target": "language:SQL/PGQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sparkledb",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:sparksee",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stardog",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stardog",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stardog",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stellardb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stellardb",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:strabon",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:strabon",
+            "target": "language:stSPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:strabon",
+            "target": "language:GeoSPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:stromadb",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:surrealdb",
+            "target": "language:SurrealQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:surrealdb",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:surrealdb",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tao",
+            "target": "language:TAO API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tentris",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:terminusdb",
+            "target": "language:WOQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:terminusdb",
+            "target": "language:GraphQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tigergraph",
+            "target": "language:GSQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tinkergraph",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:traverse",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:traverse",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:triblespace",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tugraph",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:tugraph",
+            "target": "language:GQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:turbolynx",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:turingdb",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:typedb",
+            "target": "language:TypeQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:ultipa",
+            "target": "language:UQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:velocitygraph",
+            "target": "language:LINQ",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:virtuoso",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:virtuoso",
+            "target": "language:SPARQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:weaver",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:youtrackdb",
+            "target": "language:Gremlin",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:youtrackdb",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:yugabytedb-mage",
+            "target": "language:openCypher",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:yugabytedb-mage",
+            "target": "language:SQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:zipg",
+            "target": "language:Custom API",
+            "relationship": "supports"
+          }
+        ]
+      }
+    }
+  ],
+  "config": {
+    "version": 1,
+    "layout": "force",
+    "bindings": [
+      {
+        "channel": "size",
+        "source": {
+          "kind": "algorithm",
+          "id": "degree"
+        },
+        "resultType": "num"
+      },
+      {
+        "channel": "color",
+        "source": {
+          "kind": "field",
+          "id": "kind"
+        },
+        "resultType": "cat"
+      }
+    ]
+  }
+}

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -16,6 +16,7 @@
           {
             "id": "db:4store",
             "label": "4store",
+            "image": "https://gdb-engines.com/logos/4store.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -24,6 +25,7 @@
           {
             "id": "db:aerospike",
             "label": "Aerospike Graph",
+            "image": "https://gdb-engines.com/logos/aerospike.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -32,6 +34,7 @@
           {
             "id": "db:agdb",
             "label": "agdb",
+            "image": "https://gdb-engines.com/logos/agdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -40,6 +43,7 @@
           {
             "id": "db:agensgraph",
             "label": "AgensGraph",
+            "image": "https://gdb-engines.com/logos/agensgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -48,6 +52,7 @@
           {
             "id": "db:akutan",
             "label": "Akutan",
+            "image": "https://gdb-engines.com/logos/akutan.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -56,6 +61,7 @@
           {
             "id": "db:alibaba-gdb",
             "label": "Alibaba GDB",
+            "image": "https://gdb-engines.com/logos/alibaba-gdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -64,6 +70,7 @@
           {
             "id": "db:allegrograph",
             "label": "AllegroGraph",
+            "image": "https://gdb-engines.com/logos/allegrograph.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -72,6 +79,7 @@
           {
             "id": "db:altair-graph-lakehouse",
             "label": "Altair Graph Lakehouse",
+            "image": "https://gdb-engines.com/logos/altair-graph-lakehouse.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Enterprise",
@@ -80,6 +88,7 @@
           {
             "id": "db:apache-age",
             "label": "Apache AGE",
+            "image": "https://gdb-engines.com/logos/apache-age.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -88,6 +97,7 @@
           {
             "id": "db:apache-giraph",
             "label": "Apache Giraph",
+            "image": "https://gdb-engines.com/logos/apache-giraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -96,6 +106,7 @@
           {
             "id": "db:apache-hugegraph",
             "label": "Apache HugeGraph",
+            "image": "https://gdb-engines.com/logos/apache-hugegraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -104,6 +115,7 @@
           {
             "id": "db:apache-jena-fuseki",
             "label": "Apache Jena Fuseki",
+            "image": "https://gdb-engines.com/logos/apache-jena-fuseki.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -112,6 +124,7 @@
           {
             "id": "db:apache-rya",
             "label": "Apache Rya",
+            "image": "https://gdb-engines.com/logos/apache-rya.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -120,6 +133,7 @@
           {
             "id": "db:arangodb",
             "label": "ArangoDB",
+            "image": "https://gdb-engines.com/logos/arangodb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -128,6 +142,7 @@
           {
             "id": "db:arcadedb",
             "label": "ArcadeDB",
+            "image": "https://gdb-engines.com/logos/arcadedb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Growing",
@@ -136,6 +151,7 @@
           {
             "id": "db:atomic-server",
             "label": "Atomic Server",
+            "image": "https://gdb-engines.com/logos/atomic-server.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -144,6 +160,7 @@
           {
             "id": "db:attean",
             "label": "Attean",
+            "image": "https://gdb-engines.com/logos/attean.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -152,6 +169,7 @@
           {
             "id": "db:bangdb",
             "label": "BangDB",
+            "image": "https://gdb-engines.com/logos/bangdb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -160,6 +178,7 @@
           {
             "id": "db:bighorn",
             "label": "Bighorn",
+            "image": "https://gdb-engines.com/logos/bighorn.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -168,6 +187,7 @@
           {
             "id": "db:bigquery-graph",
             "label": "Google Cloud BigQuery Graph",
+            "image": "https://gdb-engines.com/logos/bigquery-graph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -176,6 +196,7 @@
           {
             "id": "db:bitsy",
             "label": "Bitsy",
+            "image": "https://gdb-engines.com/logos/bitsy.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -184,6 +205,7 @@
           {
             "id": "db:blazegraph",
             "label": "BlazeGraph",
+            "image": "https://gdb-engines.com/logos/blazegraph.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -192,6 +214,7 @@
           {
             "id": "db:brightstardb",
             "label": "BrightstarDB",
+            "image": "https://gdb-engines.com/logos/brightstardb.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -200,6 +223,7 @@
           {
             "id": "db:bytegraph",
             "label": "ByteGraph",
+            "image": "https://gdb-engines.com/logos/bytegraph.png",
             "kind": "Database",
             "type": "Other",
             "category": "Enterprise",
@@ -208,6 +232,7 @@
           {
             "id": "db:chronograph",
             "label": "ChronoGraph",
+            "image": "https://gdb-engines.com/logos/chronograph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -216,6 +241,7 @@
           {
             "id": "db:codemix-graph",
             "label": "CodeMix Graph",
+            "image": "https://gdb-engines.com/logos/codemix-graph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -224,6 +250,7 @@
           {
             "id": "db:cogdb",
             "label": "CogDB",
+            "image": "https://gdb-engines.com/logos/cogdb.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -232,6 +259,7 @@
           {
             "id": "db:comunica",
             "label": "Comunica",
+            "image": "https://gdb-engines.com/logos/comunica.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -240,6 +268,7 @@
           {
             "id": "db:cosmos-db",
             "label": "Cosmos DB",
+            "image": "https://gdb-engines.com/logos/cosmos-db.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -248,6 +277,7 @@
           {
             "id": "db:cray-graph-engine",
             "label": "Cray Graph Engine",
+            "image": "https://gdb-engines.com/logos/cray-graph-engine.png",
             "kind": "Database",
             "type": "Other",
             "category": "Enterprise",
@@ -256,6 +286,7 @@
           {
             "id": "db:data-graphs",
             "label": "Data Graphs",
+            "image": "https://gdb-engines.com/logos/data-graphs.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -264,6 +295,7 @@
           {
             "id": "db:datastax-enterprise",
             "label": "DataStax Enterprise",
+            "image": "https://gdb-engines.com/logos/datastax-enterprise.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -272,6 +304,7 @@
           {
             "id": "db:dgraph",
             "label": "Dgraph",
+            "image": "https://gdb-engines.com/logos/dgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -280,6 +313,7 @@
           {
             "id": "db:dozerdb",
             "label": "DozerDB",
+            "image": "https://gdb-engines.com/logos/dozerdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -288,6 +322,7 @@
           {
             "id": "db:duckpgq",
             "label": "DuckPGQ",
+            "image": "https://gdb-engines.com/logos/duckpgq.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -296,6 +331,7 @@
           {
             "id": "db:dydra",
             "label": "Dydra",
+            "image": "https://gdb-engines.com/logos/dydra.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -304,6 +340,7 @@
           {
             "id": "db:eclipse-rdf4j",
             "label": "Eclipse RDF4J",
+            "image": "https://gdb-engines.com/logos/eclipse-rdf4j.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -312,6 +349,7 @@
           {
             "id": "db:fabric-graph",
             "label": "Microsoft Fabric Graph",
+            "image": "https://gdb-engines.com/logos/fabric-graph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -320,6 +358,7 @@
           {
             "id": "db:falkordblite",
             "label": "FalkorDBLite",
+            "image": "https://gdb-engines.com/logos/falkordblite.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -328,6 +367,7 @@
           {
             "id": "db:faunadb",
             "label": "FaunaDB",
+            "image": "https://gdb-engines.com/logos/faunadb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -336,6 +376,7 @@
           {
             "id": "db:flockdb",
             "label": "FlockDB",
+            "image": "https://gdb-engines.com/logos/flockdb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Established",
@@ -344,6 +385,7 @@
           {
             "id": "db:fluree",
             "label": "Fluree",
+            "image": "https://gdb-engines.com/logos/fluree.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Growing",
@@ -352,6 +394,7 @@
           {
             "id": "db:frogql",
             "label": "froGQL",
+            "image": "https://gdb-engines.com/logos/frogql.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -360,6 +403,7 @@
           {
             "id": "db:g-tran",
             "label": "G-Tran",
+            "image": "https://gdb-engines.com/logos/g-tran.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -368,6 +412,7 @@
           {
             "id": "db:gaffer",
             "label": "Gaffer",
+            "image": "https://gdb-engines.com/logos/gaffer.png",
             "kind": "Database",
             "type": "Other",
             "category": "Established",
@@ -376,6 +421,7 @@
           {
             "id": "db:galaxybase",
             "label": "GalaxyBase",
+            "image": "https://gdb-engines.com/logos/galaxybase.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -384,6 +430,7 @@
           {
             "id": "db:gfql",
             "label": "GFQL",
+            "image": "https://gdb-engines.com/logos/gfql.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -392,6 +439,7 @@
           {
             "id": "db:google-cayley",
             "label": "Google Cayley",
+            "image": "https://gdb-engines.com/logos/google-cayley.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -400,6 +448,7 @@
           {
             "id": "db:grafeo",
             "label": "Grafeo",
+            "image": "https://gdb-engines.com/logos/grafeo.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -408,6 +457,7 @@
           {
             "id": "db:graph-engine",
             "label": "Graph Engine",
+            "image": "https://gdb-engines.com/logos/graph-engine.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -416,6 +466,7 @@
           {
             "id": "db:graphbase",
             "label": "GraphBase",
+            "image": "https://gdb-engines.com/logos/graphbase.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -424,6 +475,7 @@
           {
             "id": "db:graphflow",
             "label": "Graphflow",
+            "image": "https://gdb-engines.com/logos/graphflow.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -432,6 +484,7 @@
           {
             "id": "db:graphlite",
             "label": "GraphLite",
+            "image": "https://gdb-engines.com/logos/graphlite.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -440,6 +493,7 @@
           {
             "id": "db:graphqlite",
             "label": "GraphQLite",
+            "image": "https://gdb-engines.com/logos/graphqlite.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -448,6 +502,7 @@
           {
             "id": "db:graphscope",
             "label": "GraphScope",
+            "image": "https://gdb-engines.com/logos/graphscope.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -456,6 +511,7 @@
           {
             "id": "db:grust",
             "label": "Grust",
+            "image": "https://gdb-engines.com/logos/grust.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -464,6 +520,7 @@
           {
             "id": "db:gstore",
             "label": "gStore",
+            "image": "https://gdb-engines.com/logos/gstore.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -472,6 +529,7 @@
           {
             "id": "db:gun",
             "label": "GUN",
+            "image": "https://gdb-engines.com/logos/gun.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -480,6 +538,7 @@
           {
             "id": "db:halyard",
             "label": "Halyard",
+            "image": "https://gdb-engines.com/logos/halyard.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -488,6 +547,7 @@
           {
             "id": "db:helixdb",
             "label": "HelixDB",
+            "image": "https://gdb-engines.com/logos/helixdb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -496,6 +556,7 @@
           {
             "id": "db:hgraphdb",
             "label": "HGraphDB",
+            "image": "https://gdb-engines.com/logos/hgraphdb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -504,6 +565,7 @@
           {
             "id": "db:huawei-ges",
             "label": "Huawei Graph Engine Service",
+            "image": "https://gdb-engines.com/logos/huawei-ges.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -512,6 +574,7 @@
           {
             "id": "db:hypergraphdb",
             "label": "HyperGraphDB",
+            "image": "https://gdb-engines.com/logos/hypergraphdb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -520,6 +583,7 @@
           {
             "id": "db:ibm-system-g",
             "label": "IBM System G",
+            "image": "https://gdb-engines.com/logos/ibm-system-g.png",
             "kind": "Database",
             "type": "Other",
             "category": "Enterprise",
@@ -528,6 +592,7 @@
           {
             "id": "db:infinitegraph",
             "label": "InfiniteGraph",
+            "image": "https://gdb-engines.com/logos/infinitegraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -536,6 +601,7 @@
           {
             "id": "db:janusgraph",
             "label": "JanusGraph",
+            "image": "https://gdb-engines.com/logos/janusgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -544,6 +610,7 @@
           {
             "id": "db:katanagraph",
             "label": "KatanaGraph",
+            "image": "https://gdb-engines.com/logos/katanagraph.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -552,6 +619,7 @@
           {
             "id": "db:kglite",
             "label": "KGLite",
+            "image": "https://gdb-engines.com/logos/kglite.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -560,6 +628,7 @@
           {
             "id": "db:kinetica",
             "label": "Kinetica",
+            "image": "https://gdb-engines.com/logos/kinetica.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Established",
@@ -568,6 +637,7 @@
           {
             "id": "db:kuzu",
             "label": "Kuzu",
+            "image": "https://gdb-engines.com/logos/kuzu.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -576,6 +646,7 @@
           {
             "id": "db:ladybugdb",
             "label": "LadybugDB",
+            "image": "https://gdb-engines.com/logos/ladybugdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -584,6 +655,7 @@
           {
             "id": "db:lance-graph",
             "label": "Lance Graph",
+            "image": "https://gdb-engines.com/logos/lance-graph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -592,6 +664,7 @@
           {
             "id": "db:livegraph",
             "label": "LiveGraph",
+            "image": "https://gdb-engines.com/logos/livegraph.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -600,6 +673,7 @@
           {
             "id": "db:marklogic",
             "label": "MarkLogic",
+            "image": "https://gdb-engines.com/logos/marklogic.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -608,6 +682,7 @@
           {
             "id": "db:marmotta-kiwi",
             "label": "Apache Marmotta KiWi",
+            "image": "https://gdb-engines.com/logos/marmotta-kiwi.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -616,6 +691,7 @@
           {
             "id": "db:memgql",
             "label": "MemGQL",
+            "image": "https://gdb-engines.com/logos/memgql.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -624,6 +700,7 @@
           {
             "id": "db:memgraph",
             "label": "Memgraph",
+            "image": "https://gdb-engines.com/logos/memgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -632,6 +709,7 @@
           {
             "id": "db:millenniumdb",
             "label": "MillenniumDB",
+            "image": "https://gdb-engines.com/logos/millenniumdb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -640,6 +718,7 @@
           {
             "id": "db:minigraf",
             "label": "Minigraf",
+            "image": "https://gdb-engines.com/logos/minigraf.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -648,6 +727,7 @@
           {
             "id": "db:mulgara",
             "label": "Mulgara",
+            "image": "https://gdb-engines.com/logos/mulgara.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -656,6 +736,7 @@
           {
             "id": "db:nebulagraph",
             "label": "NebulaGraph",
+            "image": "https://gdb-engines.com/logos/nebulagraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -664,6 +745,7 @@
           {
             "id": "db:neo4j",
             "label": "Neo4j",
+            "image": "https://gdb-engines.com/logos/neo4j.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -672,6 +754,7 @@
           {
             "id": "db:neptune",
             "label": "Neptune",
+            "image": "https://gdb-engines.com/logos/neptune.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -680,6 +763,7 @@
           {
             "id": "db:neug",
             "label": "NeuG",
+            "image": "https://gdb-engines.com/logos/neug.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -688,14 +772,16 @@
           {
             "id": "db:nodedb",
             "label": "NodeDB",
+            "image": "https://gdb-engines.com/logos/nodedb.png",
             "kind": "Database",
-            "type": "Property Graph",
+            "type": "Multiple",
             "category": "Emerging",
             "status": "active"
           },
           {
             "id": "db:nornicdb",
             "label": "NornicDB",
+            "image": "https://gdb-engines.com/logos/nornicdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -704,6 +790,7 @@
           {
             "id": "db:objectivity-db",
             "label": "Objectivity/DB",
+            "image": "https://gdb-engines.com/logos/objectivity-db.png",
             "kind": "Database",
             "type": "Other",
             "category": "Enterprise",
@@ -712,6 +799,7 @@
           {
             "id": "db:omnigraph",
             "label": "OmniGraph",
+            "image": "https://gdb-engines.com/logos/omnigraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -720,6 +808,7 @@
           {
             "id": "db:ongdb",
             "label": "ONgDB",
+            "image": "https://gdb-engines.com/logos/ongdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -728,6 +817,7 @@
           {
             "id": "db:ontop",
             "label": "Ontop",
+            "image": "https://gdb-engines.com/logos/ontop.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -736,6 +826,7 @@
           {
             "id": "db:ontotext-graphdb",
             "label": "Ontotext GraphDB",
+            "image": "https://gdb-engines.com/logos/ontotext-graphdb.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Enterprise",
@@ -744,6 +835,7 @@
           {
             "id": "db:oracle-graph",
             "label": "Oracle Graph",
+            "image": "https://gdb-engines.com/logos/oracle-graph.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -752,6 +844,7 @@
           {
             "id": "db:orientdb",
             "label": "OrientDB",
+            "image": "https://gdb-engines.com/logos/orientdb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -760,6 +853,7 @@
           {
             "id": "db:oxigraph",
             "label": "Oxigraph",
+            "image": "https://gdb-engines.com/logos/oxigraph.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -768,6 +862,7 @@
           {
             "id": "db:oxirs",
             "label": "OxiRS",
+            "image": "https://gdb-engines.com/logos/oxirs.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -776,6 +871,7 @@
           {
             "id": "db:pandadb",
             "label": "PandaDB",
+            "image": "https://gdb-engines.com/logos/pandadb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -784,6 +880,7 @@
           {
             "id": "db:parliament",
             "label": "Parliament",
+            "image": "https://gdb-engines.com/logos/parliament.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -792,6 +889,7 @@
           {
             "id": "db:pggraph",
             "label": "pgGraph",
+            "image": "https://gdb-engines.com/logos/pggraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -800,6 +898,7 @@
           {
             "id": "db:postgresql-sql-pgq",
             "label": "PostgreSQL SQL/PGQ",
+            "image": "https://gdb-engines.com/logos/postgresql-sql-pgq.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -808,6 +907,7 @@
           {
             "id": "db:prometheux",
             "label": "Prometheux",
+            "image": "https://gdb-engines.com/logos/prometheux.png",
             "kind": "Database",
             "type": "Other",
             "category": "Growing",
@@ -816,6 +916,7 @@
           {
             "id": "db:puppygraph",
             "label": "PuppyGraph",
+            "image": "https://gdb-engines.com/logos/puppygraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -824,6 +925,7 @@
           {
             "id": "db:qlever",
             "label": "QLever",
+            "image": "https://gdb-engines.com/logos/qlever.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -832,6 +934,7 @@
           {
             "id": "db:quadstore",
             "label": "Quadstore",
+            "image": "https://gdb-engines.com/logos/quadstore.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -840,6 +943,7 @@
           {
             "id": "db:quine",
             "label": "Quine",
+            "image": "https://gdb-engines.com/logos/quine.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -848,6 +952,7 @@
           {
             "id": "db:raphtory",
             "label": "Raphtory",
+            "image": "https://gdb-engines.com/logos/raphtory.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -856,6 +961,7 @@
           {
             "id": "db:rdf-trine",
             "label": "RDF::Trine",
+            "image": "https://gdb-engines.com/logos/rdf-trine.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -864,6 +970,7 @@
           {
             "id": "db:rdflib",
             "label": "RDFLib",
+            "image": "https://gdb-engines.com/logos/rdflib.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -872,6 +979,7 @@
           {
             "id": "db:rdfox",
             "label": "RDFox",
+            "image": "https://gdb-engines.com/logos/rdfox.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Enterprise",
@@ -880,6 +988,7 @@
           {
             "id": "db:recallgraph",
             "label": "RecallGraph",
+            "image": "https://gdb-engines.com/logos/recallgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -888,6 +997,7 @@
           {
             "id": "db:redisgraph-falkordb",
             "label": "FalkorDB",
+            "image": "https://gdb-engines.com/logos/redisgraph-falkordb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -896,6 +1006,7 @@
           {
             "id": "db:redland",
             "label": "Redland",
+            "image": "https://gdb-engines.com/logos/redland.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Established",
@@ -904,6 +1015,7 @@
           {
             "id": "db:redstore",
             "label": "RedStore",
+            "image": "https://gdb-engines.com/logos/redstore.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -912,6 +1024,7 @@
           {
             "id": "db:relationalai",
             "label": "RelationalAI",
+            "image": "https://gdb-engines.com/logos/relationalai.png",
             "kind": "Database",
             "type": "Other",
             "category": "Growing",
@@ -920,6 +1033,7 @@
           {
             "id": "db:rocketgraph",
             "label": "Rocketgraph",
+            "image": "https://gdb-engines.com/logos/rocketgraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -928,6 +1042,7 @@
           {
             "id": "db:rushdb",
             "label": "RushDB",
+            "image": "https://gdb-engines.com/logos/rushdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -936,6 +1051,7 @@
           {
             "id": "db:ryugraph",
             "label": "RyuGraph",
+            "image": "https://gdb-engines.com/logos/ryugraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -944,6 +1060,7 @@
           {
             "id": "db:sap-hana",
             "label": "SAP Hana",
+            "image": "https://gdb-engines.com/logos/sap-hana.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -952,6 +1069,7 @@
           {
             "id": "db:sones-graphdb",
             "label": "Sones GraphDB",
+            "image": "https://gdb-engines.com/logos/sones-graphdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -960,6 +1078,7 @@
           {
             "id": "db:spanner-graph",
             "label": "Google Cloud Spanner Graph",
+            "image": "https://gdb-engines.com/logos/spanner-graph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Enterprise",
@@ -968,6 +1087,7 @@
           {
             "id": "db:sparkledb",
             "label": "SparkleDB",
+            "image": "https://gdb-engines.com/logos/sparkledb.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -976,6 +1096,7 @@
           {
             "id": "db:sparksee",
             "label": "Sparksee",
+            "image": "https://gdb-engines.com/logos/sparksee.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -984,6 +1105,7 @@
           {
             "id": "db:stardog",
             "label": "Stardog",
+            "image": "https://gdb-engines.com/logos/stardog.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Enterprise",
@@ -992,6 +1114,7 @@
           {
             "id": "db:stellardb",
             "label": "StellarDB",
+            "image": "https://gdb-engines.com/logos/stellardb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1000,6 +1123,7 @@
           {
             "id": "db:strabon",
             "label": "Strabon",
+            "image": "https://gdb-engines.com/logos/strabon.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -1008,6 +1132,7 @@
           {
             "id": "db:stromadb",
             "label": "StromaDB",
+            "image": "https://gdb-engines.com/logos/stromadb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1016,6 +1141,7 @@
           {
             "id": "db:surrealdb",
             "label": "SurrealDB",
+            "image": "https://gdb-engines.com/logos/surrealdb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Growing",
@@ -1024,6 +1150,7 @@
           {
             "id": "db:tao",
             "label": "TAO",
+            "image": "https://gdb-engines.com/logos/tao.png",
             "kind": "Database",
             "type": "Other",
             "category": "Established",
@@ -1032,6 +1159,7 @@
           {
             "id": "db:tentris",
             "label": "Tentris",
+            "image": "https://gdb-engines.com/logos/tentris.png",
             "kind": "Database",
             "type": "RDF",
             "category": "Emerging",
@@ -1040,6 +1168,7 @@
           {
             "id": "db:terminusdb",
             "label": "TerminusDB",
+            "image": "https://gdb-engines.com/logos/terminusdb.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Emerging",
@@ -1048,6 +1177,7 @@
           {
             "id": "db:tigergraph",
             "label": "TigerGraph",
+            "image": "https://gdb-engines.com/logos/tigergraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -1056,6 +1186,7 @@
           {
             "id": "db:tinkergraph",
             "label": "TinkerGraph",
+            "image": "https://gdb-engines.com/logos/tinkergraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -1064,6 +1195,7 @@
           {
             "id": "db:traverse",
             "label": "Traverse",
+            "image": "https://gdb-engines.com/logos/traverse.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1072,6 +1204,7 @@
           {
             "id": "db:triblespace",
             "label": "TribleSpace",
+            "image": "https://gdb-engines.com/logos/triblespace.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -1080,6 +1213,7 @@
           {
             "id": "db:tugraph",
             "label": "TuGraph",
+            "image": "https://gdb-engines.com/logos/tugraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Established",
@@ -1088,6 +1222,7 @@
           {
             "id": "db:turbolynx",
             "label": "TurboLynx",
+            "image": "https://gdb-engines.com/logos/turbolynx.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1096,6 +1231,7 @@
           {
             "id": "db:turingdb",
             "label": "TuringDB",
+            "image": "https://gdb-engines.com/logos/turingdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1104,6 +1240,7 @@
           {
             "id": "db:typedb",
             "label": "TypeDB",
+            "image": "https://gdb-engines.com/logos/typedb.png",
             "kind": "Database",
             "type": "Other",
             "category": "Growing",
@@ -1112,6 +1249,7 @@
           {
             "id": "db:ultipa",
             "label": "Ultipa",
+            "image": "https://gdb-engines.com/logos/ultipa.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Growing",
@@ -1120,6 +1258,7 @@
           {
             "id": "db:velocitygraph",
             "label": "VelocityGraph",
+            "image": "https://gdb-engines.com/logos/velocitygraph.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1128,6 +1267,7 @@
           {
             "id": "db:virtuoso",
             "label": "Virtuoso",
+            "image": "https://gdb-engines.com/logos/virtuoso.png",
             "kind": "Database",
             "type": "Multiple",
             "category": "Enterprise",
@@ -1136,6 +1276,7 @@
           {
             "id": "db:weaver",
             "label": "Weaver",
+            "image": "https://gdb-engines.com/logos/weaver.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -1144,6 +1285,7 @@
           {
             "id": "db:youtrackdb",
             "label": "YouTrackDB",
+            "image": "https://gdb-engines.com/logos/youtrackdb.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1152,6 +1294,7 @@
           {
             "id": "db:yugabytedb-mage",
             "label": "YugabyteDB MAGE",
+            "image": "https://gdb-engines.com/logos/yugabytedb-mage.png",
             "kind": "Database",
             "type": "Property Graph",
             "category": "Emerging",
@@ -1160,6 +1303,7 @@
           {
             "id": "db:zipg",
             "label": "ZipG",
+            "image": "https://gdb-engines.com/logos/zipg.png",
             "kind": "Database",
             "type": "Other",
             "category": "Emerging",
@@ -1989,12 +2133,12 @@
           },
           {
             "source": "db:nodedb",
-            "target": "language:Cypher",
+            "target": "language:SQL",
             "relationship": "supports"
           },
           {
             "source": "db:nodedb",
-            "target": "language:SQL",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -2422,6 +2566,14 @@
           "id": "degree"
         },
         "resultType": "num"
+      },
+      {
+        "channel": "image",
+        "source": {
+          "kind": "field",
+          "id": "image"
+        },
+        "resultType": "cat"
       },
       {
         "channel": "color",

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -1707,7 +1707,7 @@
           },
           {
             "source": "db:codemix-graph",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -1862,7 +1862,7 @@
           },
           {
             "source": "db:gfql",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -1887,7 +1887,7 @@
           },
           {
             "source": "db:grafeo",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -2137,7 +2137,7 @@
           },
           {
             "source": "db:neug",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -2152,7 +2152,7 @@
           },
           {
             "source": "db:nornicdb",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {
@@ -2327,7 +2327,7 @@
           },
           {
             "source": "db:rocketgraph",
-            "target": "language:Cypher",
+            "target": "language:openCypher",
             "relationship": "supports"
           },
           {

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -1247,6 +1247,15 @@
             "status": "active"
           },
           {
+            "id": "db:typegraph",
+            "label": "TypeGraph",
+            "image": "https://gdb-engines.com/logos/typegraph.png",
+            "kind": "Database",
+            "type": "Property Graph",
+            "category": "Emerging",
+            "status": "active"
+          },
+          {
             "id": "db:ultipa",
             "label": "Ultipa",
             "image": "https://gdb-engines.com/logos/ultipa.png",
@@ -2499,6 +2508,11 @@
           {
             "source": "db:typedb",
             "target": "language:TypeQL",
+            "relationship": "supports"
+          },
+          {
+            "source": "db:typegraph",
+            "target": "language:Custom API",
             "relationship": "supports"
           },
           {

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -2576,15 +2576,6 @@
         "resultType": "cat"
       },
       {
-        "channel": "hull",
-        "source": {
-          "kind": "field",
-          "id": "type"
-        },
-        "resultType": "cat",
-        "enabled": false
-      },
-      {
         "channel": "color",
         "source": {
           "kind": "field",

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -2576,6 +2576,15 @@
         "resultType": "cat"
       },
       {
+        "channel": "hull",
+        "source": {
+          "kind": "field",
+          "id": "type"
+        },
+        "resultType": "cat",
+        "enabled": false
+      },
+      {
         "channel": "color",
         "source": {
           "kind": "field",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -1658,6 +1658,18 @@
             "queryLanguages": "TypeQL"
           },
           {
+            "id": "db:typegraph",
+            "label": "TypeGraph",
+            "image": "https://gdb-engines.com/logos/typegraph.png",
+            "type": "Property Graph",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "TypeScript",
+            "queryLanguages": "Custom API"
+          },
+          {
             "id": "db:ultipa",
             "label": "Ultipa",
             "image": "https://gdb-engines.com/logos/ultipa.png",
@@ -2105,6 +2117,11 @@
           },
           {
             "source": "db:codemix-graph",
+            "target": "db:typegraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:codemix-graph",
             "target": "db:nornicdb",
             "similarity": 0.4
           },
@@ -2112,11 +2129,6 @@
             "source": "db:codemix-graph",
             "target": "db:rocketgraph",
             "similarity": 0.3333
-          },
-          {
-            "source": "db:bighorn",
-            "target": "db:codemix-graph",
-            "similarity": 0.3
           },
           {
             "source": "db:cogdb",
@@ -3114,9 +3126,9 @@
             "similarity": 0.5
           },
           {
-            "source": "db:galaxybase",
-            "target": "db:rushdb",
-            "similarity": 0.375
+            "source": "db:rushdb",
+            "target": "db:typegraph",
+            "similarity": 0.5
           },
           {
             "source": "db:bighorn",
@@ -3292,6 +3304,16 @@
             "source": "db:relationalai",
             "target": "db:typedb",
             "similarity": 0.3
+          },
+          {
+            "source": "db:grust",
+            "target": "db:typegraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:omnigraph",
+            "target": "db:typegraph",
+            "similarity": 0.5
           },
           {
             "source": "db:alibaba-gdb",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -16,6 +16,7 @@
           {
             "id": "db:4store",
             "label": "4store",
+            "image": "https://gdb-engines.com/logos/4store.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -27,6 +28,7 @@
           {
             "id": "db:aerospike",
             "label": "Aerospike Graph",
+            "image": "https://gdb-engines.com/logos/aerospike.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -38,6 +40,7 @@
           {
             "id": "db:agdb",
             "label": "agdb",
+            "image": "https://gdb-engines.com/logos/agdb.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -49,6 +52,7 @@
           {
             "id": "db:agensgraph",
             "label": "AgensGraph",
+            "image": "https://gdb-engines.com/logos/agensgraph.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Growing",
@@ -60,6 +64,7 @@
           {
             "id": "db:akutan",
             "label": "Akutan",
+            "image": "https://gdb-engines.com/logos/akutan.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -71,6 +76,7 @@
           {
             "id": "db:alibaba-gdb",
             "label": "Alibaba GDB",
+            "image": "https://gdb-engines.com/logos/alibaba-gdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -82,6 +88,7 @@
           {
             "id": "db:allegrograph",
             "label": "AllegroGraph",
+            "image": "https://gdb-engines.com/logos/allegrograph.png",
             "type": "RDF",
             "kind": "database",
             "category": "Established",
@@ -93,6 +100,7 @@
           {
             "id": "db:altair-graph-lakehouse",
             "label": "Altair Graph Lakehouse",
+            "image": "https://gdb-engines.com/logos/altair-graph-lakehouse.png",
             "type": "RDF",
             "kind": "database",
             "category": "Enterprise",
@@ -104,6 +112,7 @@
           {
             "id": "db:apache-age",
             "label": "Apache AGE",
+            "image": "https://gdb-engines.com/logos/apache-age.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Established",
@@ -115,6 +124,7 @@
           {
             "id": "db:apache-giraph",
             "label": "Apache Giraph",
+            "image": "https://gdb-engines.com/logos/apache-giraph.png",
             "type": "Property Graph",
             "kind": "query-engine",
             "category": "Established",
@@ -126,6 +136,7 @@
           {
             "id": "db:apache-hugegraph",
             "label": "Apache HugeGraph",
+            "image": "https://gdb-engines.com/logos/apache-hugegraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -137,6 +148,7 @@
           {
             "id": "db:apache-jena-fuseki",
             "label": "Apache Jena Fuseki",
+            "image": "https://gdb-engines.com/logos/apache-jena-fuseki.png",
             "type": "RDF",
             "kind": "database",
             "category": "Established",
@@ -148,6 +160,7 @@
           {
             "id": "db:apache-rya",
             "label": "Apache Rya",
+            "image": "https://gdb-engines.com/logos/apache-rya.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -159,6 +172,7 @@
           {
             "id": "db:arangodb",
             "label": "ArangoDB",
+            "image": "https://gdb-engines.com/logos/arangodb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -170,6 +184,7 @@
           {
             "id": "db:arcadedb",
             "label": "ArcadeDB",
+            "image": "https://gdb-engines.com/logos/arcadedb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Growing",
@@ -181,6 +196,7 @@
           {
             "id": "db:atomic-server",
             "label": "Atomic Server",
+            "image": "https://gdb-engines.com/logos/atomic-server.png",
             "type": "Other",
             "kind": "database",
             "category": "Emerging",
@@ -192,6 +208,7 @@
           {
             "id": "db:attean",
             "label": "Attean",
+            "image": "https://gdb-engines.com/logos/attean.png",
             "type": "RDF",
             "kind": "library",
             "category": "Emerging",
@@ -203,6 +220,7 @@
           {
             "id": "db:bangdb",
             "label": "BangDB",
+            "image": "https://gdb-engines.com/logos/bangdb.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -214,6 +232,7 @@
           {
             "id": "db:bighorn",
             "label": "Bighorn",
+            "image": "https://gdb-engines.com/logos/bighorn.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -225,6 +244,7 @@
           {
             "id": "db:bigquery-graph",
             "label": "Google Cloud BigQuery Graph",
+            "image": "https://gdb-engines.com/logos/bigquery-graph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -236,6 +256,7 @@
           {
             "id": "db:bitsy",
             "label": "Bitsy",
+            "image": "https://gdb-engines.com/logos/bitsy.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -247,6 +268,7 @@
           {
             "id": "db:blazegraph",
             "label": "BlazeGraph",
+            "image": "https://gdb-engines.com/logos/blazegraph.png",
             "type": "RDF",
             "kind": "database",
             "category": "Established",
@@ -258,6 +280,7 @@
           {
             "id": "db:brightstardb",
             "label": "BrightstarDB",
+            "image": "https://gdb-engines.com/logos/brightstardb.png",
             "type": "RDF",
             "kind": "embedded",
             "category": "Emerging",
@@ -269,6 +292,7 @@
           {
             "id": "db:bytegraph",
             "label": "ByteGraph",
+            "image": "https://gdb-engines.com/logos/bytegraph.png",
             "type": "Other",
             "kind": "database",
             "category": "Enterprise",
@@ -280,6 +304,7 @@
           {
             "id": "db:chronograph",
             "label": "ChronoGraph",
+            "image": "https://gdb-engines.com/logos/chronograph.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -291,6 +316,7 @@
           {
             "id": "db:codemix-graph",
             "label": "CodeMix Graph",
+            "image": "https://gdb-engines.com/logos/codemix-graph.png",
             "type": "Property Graph",
             "kind": "library",
             "category": "Emerging",
@@ -302,6 +328,7 @@
           {
             "id": "db:cogdb",
             "label": "CogDB",
+            "image": "https://gdb-engines.com/logos/cogdb.png",
             "type": "RDF",
             "kind": "embedded",
             "category": "Emerging",
@@ -313,6 +340,7 @@
           {
             "id": "db:comunica",
             "label": "Comunica",
+            "image": "https://gdb-engines.com/logos/comunica.png",
             "type": "RDF",
             "kind": "query-engine",
             "category": "Emerging",
@@ -324,6 +352,7 @@
           {
             "id": "db:cosmos-db",
             "label": "Cosmos DB",
+            "image": "https://gdb-engines.com/logos/cosmos-db.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -335,6 +364,7 @@
           {
             "id": "db:cray-graph-engine",
             "label": "Cray Graph Engine",
+            "image": "https://gdb-engines.com/logos/cray-graph-engine.png",
             "type": "Other",
             "kind": "database",
             "category": "Enterprise",
@@ -346,6 +376,7 @@
           {
             "id": "db:data-graphs",
             "label": "Data Graphs",
+            "image": "https://gdb-engines.com/logos/data-graphs.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
@@ -357,6 +388,7 @@
           {
             "id": "db:datastax-enterprise",
             "label": "DataStax Enterprise",
+            "image": "https://gdb-engines.com/logos/datastax-enterprise.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -368,6 +400,7 @@
           {
             "id": "db:dgraph",
             "label": "Dgraph",
+            "image": "https://gdb-engines.com/logos/dgraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -379,6 +412,7 @@
           {
             "id": "db:dozerdb",
             "label": "DozerDB",
+            "image": "https://gdb-engines.com/logos/dozerdb.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -390,6 +424,7 @@
           {
             "id": "db:duckpgq",
             "label": "DuckPGQ",
+            "image": "https://gdb-engines.com/logos/duckpgq.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -401,6 +436,7 @@
           {
             "id": "db:dydra",
             "label": "Dydra",
+            "image": "https://gdb-engines.com/logos/dydra.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -412,6 +448,7 @@
           {
             "id": "db:eclipse-rdf4j",
             "label": "Eclipse RDF4J",
+            "image": "https://gdb-engines.com/logos/eclipse-rdf4j.png",
             "type": "RDF",
             "kind": "database",
             "category": "Established",
@@ -423,6 +460,7 @@
           {
             "id": "db:fabric-graph",
             "label": "Microsoft Fabric Graph",
+            "image": "https://gdb-engines.com/logos/fabric-graph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -434,6 +472,7 @@
           {
             "id": "db:falkordblite",
             "label": "FalkorDBLite",
+            "image": "https://gdb-engines.com/logos/falkordblite.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -445,6 +484,7 @@
           {
             "id": "db:faunadb",
             "label": "FaunaDB",
+            "image": "https://gdb-engines.com/logos/faunadb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
@@ -456,6 +496,7 @@
           {
             "id": "db:flockdb",
             "label": "FlockDB",
+            "image": "https://gdb-engines.com/logos/flockdb.png",
             "type": "Other",
             "kind": "database",
             "category": "Established",
@@ -467,6 +508,7 @@
           {
             "id": "db:fluree",
             "label": "Fluree",
+            "image": "https://gdb-engines.com/logos/fluree.png",
             "type": "RDF",
             "kind": "database",
             "category": "Growing",
@@ -478,6 +520,7 @@
           {
             "id": "db:frogql",
             "label": "froGQL",
+            "image": "https://gdb-engines.com/logos/frogql.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -489,6 +532,7 @@
           {
             "id": "db:g-tran",
             "label": "G-Tran",
+            "image": "https://gdb-engines.com/logos/g-tran.png",
             "type": "Other",
             "kind": "database",
             "category": "Emerging",
@@ -500,6 +544,7 @@
           {
             "id": "db:gaffer",
             "label": "Gaffer",
+            "image": "https://gdb-engines.com/logos/gaffer.png",
             "type": "Other",
             "kind": "query-engine",
             "category": "Established",
@@ -511,6 +556,7 @@
           {
             "id": "db:galaxybase",
             "label": "GalaxyBase",
+            "image": "https://gdb-engines.com/logos/galaxybase.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -522,6 +568,7 @@
           {
             "id": "db:gfql",
             "label": "GFQL",
+            "image": "https://gdb-engines.com/logos/gfql.png",
             "type": "Property Graph",
             "kind": "query-engine",
             "category": "Growing",
@@ -533,6 +580,7 @@
           {
             "id": "db:google-cayley",
             "label": "Google Cayley",
+            "image": "https://gdb-engines.com/logos/google-cayley.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -544,6 +592,7 @@
           {
             "id": "db:grafeo",
             "label": "Grafeo",
+            "image": "https://gdb-engines.com/logos/grafeo.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
@@ -555,6 +604,7 @@
           {
             "id": "db:graph-engine",
             "label": "Graph Engine",
+            "image": "https://gdb-engines.com/logos/graph-engine.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -566,6 +616,7 @@
           {
             "id": "db:graphbase",
             "label": "GraphBase",
+            "image": "https://gdb-engines.com/logos/graphbase.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -577,6 +628,7 @@
           {
             "id": "db:graphflow",
             "label": "Graphflow",
+            "image": "https://gdb-engines.com/logos/graphflow.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -588,6 +640,7 @@
           {
             "id": "db:graphlite",
             "label": "GraphLite",
+            "image": "https://gdb-engines.com/logos/graphlite.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -599,6 +652,7 @@
           {
             "id": "db:graphqlite",
             "label": "GraphQLite",
+            "image": "https://gdb-engines.com/logos/graphqlite.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -610,6 +664,7 @@
           {
             "id": "db:graphscope",
             "label": "GraphScope",
+            "image": "https://gdb-engines.com/logos/graphscope.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Growing",
@@ -621,6 +676,7 @@
           {
             "id": "db:grust",
             "label": "Grust",
+            "image": "https://gdb-engines.com/logos/grust.png",
             "type": "Property Graph",
             "kind": "library",
             "category": "Emerging",
@@ -632,6 +688,7 @@
           {
             "id": "db:gstore",
             "label": "gStore",
+            "image": "https://gdb-engines.com/logos/gstore.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -643,6 +700,7 @@
           {
             "id": "db:gun",
             "label": "GUN",
+            "image": "https://gdb-engines.com/logos/gun.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -654,6 +712,7 @@
           {
             "id": "db:halyard",
             "label": "Halyard",
+            "image": "https://gdb-engines.com/logos/halyard.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -665,6 +724,7 @@
           {
             "id": "db:helixdb",
             "label": "HelixDB",
+            "image": "https://gdb-engines.com/logos/helixdb.png",
             "type": "Other",
             "kind": "database",
             "category": "Emerging",
@@ -676,6 +736,7 @@
           {
             "id": "db:hgraphdb",
             "label": "HGraphDB",
+            "image": "https://gdb-engines.com/logos/hgraphdb.png",
             "type": "Other",
             "kind": "extension",
             "category": "Emerging",
@@ -687,6 +748,7 @@
           {
             "id": "db:huawei-ges",
             "label": "Huawei Graph Engine Service",
+            "image": "https://gdb-engines.com/logos/huawei-ges.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -698,6 +760,7 @@
           {
             "id": "db:hypergraphdb",
             "label": "HyperGraphDB",
+            "image": "https://gdb-engines.com/logos/hypergraphdb.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -709,6 +772,7 @@
           {
             "id": "db:ibm-system-g",
             "label": "IBM System G",
+            "image": "https://gdb-engines.com/logos/ibm-system-g.png",
             "type": "Other",
             "kind": "database",
             "category": "Enterprise",
@@ -720,6 +784,7 @@
           {
             "id": "db:infinitegraph",
             "label": "InfiniteGraph",
+            "image": "https://gdb-engines.com/logos/infinitegraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -731,6 +796,7 @@
           {
             "id": "db:janusgraph",
             "label": "JanusGraph",
+            "image": "https://gdb-engines.com/logos/janusgraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -742,6 +808,7 @@
           {
             "id": "db:katanagraph",
             "label": "KatanaGraph",
+            "image": "https://gdb-engines.com/logos/katanagraph.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -753,6 +820,7 @@
           {
             "id": "db:kglite",
             "label": "KGLite",
+            "image": "https://gdb-engines.com/logos/kglite.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -764,6 +832,7 @@
           {
             "id": "db:kinetica",
             "label": "Kinetica",
+            "image": "https://gdb-engines.com/logos/kinetica.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Established",
@@ -775,6 +844,7 @@
           {
             "id": "db:kuzu",
             "label": "Kuzu",
+            "image": "https://gdb-engines.com/logos/kuzu.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -786,6 +856,7 @@
           {
             "id": "db:ladybugdb",
             "label": "LadybugDB",
+            "image": "https://gdb-engines.com/logos/ladybugdb.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Growing",
@@ -797,6 +868,7 @@
           {
             "id": "db:lance-graph",
             "label": "Lance Graph",
+            "image": "https://gdb-engines.com/logos/lance-graph.png",
             "type": "Property Graph",
             "kind": "query-engine",
             "category": "Emerging",
@@ -808,6 +880,7 @@
           {
             "id": "db:livegraph",
             "label": "LiveGraph",
+            "image": "https://gdb-engines.com/logos/livegraph.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -819,6 +892,7 @@
           {
             "id": "db:marklogic",
             "label": "MarkLogic",
+            "image": "https://gdb-engines.com/logos/marklogic.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -830,6 +904,7 @@
           {
             "id": "db:marmotta-kiwi",
             "label": "Apache Marmotta KiWi",
+            "image": "https://gdb-engines.com/logos/marmotta-kiwi.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -841,6 +916,7 @@
           {
             "id": "db:memgql",
             "label": "MemGQL",
+            "image": "https://gdb-engines.com/logos/memgql.png",
             "type": "Multiple",
             "kind": "query-engine",
             "category": "Emerging",
@@ -852,6 +928,7 @@
           {
             "id": "db:memgraph",
             "label": "Memgraph",
+            "image": "https://gdb-engines.com/logos/memgraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -863,6 +940,7 @@
           {
             "id": "db:millenniumdb",
             "label": "MillenniumDB",
+            "image": "https://gdb-engines.com/logos/millenniumdb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
@@ -874,6 +952,7 @@
           {
             "id": "db:minigraf",
             "label": "Minigraf",
+            "image": "https://gdb-engines.com/logos/minigraf.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -885,6 +964,7 @@
           {
             "id": "db:mulgara",
             "label": "Mulgara",
+            "image": "https://gdb-engines.com/logos/mulgara.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -896,6 +976,7 @@
           {
             "id": "db:nebulagraph",
             "label": "NebulaGraph",
+            "image": "https://gdb-engines.com/logos/nebulagraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -907,6 +988,7 @@
           {
             "id": "db:neo4j",
             "label": "Neo4j",
+            "image": "https://gdb-engines.com/logos/neo4j.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -918,6 +1000,7 @@
           {
             "id": "db:neptune",
             "label": "Neptune",
+            "image": "https://gdb-engines.com/logos/neptune.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -929,6 +1012,7 @@
           {
             "id": "db:neug",
             "label": "NeuG",
+            "image": "https://gdb-engines.com/logos/neug.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -940,17 +1024,19 @@
           {
             "id": "db:nodedb",
             "label": "NodeDB",
-            "type": "Property Graph",
+            "image": "https://gdb-engines.com/logos/nodedb.png",
+            "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
             "status": "active",
             "license": "BUSL-1.1",
             "implementationLanguage": "Rust",
-            "queryLanguages": "Cypher, SQL"
+            "queryLanguages": "SQL, openCypher"
           },
           {
             "id": "db:nornicdb",
             "label": "NornicDB",
+            "image": "https://gdb-engines.com/logos/nornicdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -962,6 +1048,7 @@
           {
             "id": "db:objectivity-db",
             "label": "Objectivity/DB",
+            "image": "https://gdb-engines.com/logos/objectivity-db.png",
             "type": "Other",
             "kind": "database",
             "category": "Enterprise",
@@ -973,6 +1060,7 @@
           {
             "id": "db:omnigraph",
             "label": "OmniGraph",
+            "image": "https://gdb-engines.com/logos/omnigraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -984,6 +1072,7 @@
           {
             "id": "db:ongdb",
             "label": "ONgDB",
+            "image": "https://gdb-engines.com/logos/ongdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -995,6 +1084,7 @@
           {
             "id": "db:ontop",
             "label": "Ontop",
+            "image": "https://gdb-engines.com/logos/ontop.png",
             "type": "RDF",
             "kind": "query-engine",
             "category": "Established",
@@ -1006,6 +1096,7 @@
           {
             "id": "db:ontotext-graphdb",
             "label": "Ontotext GraphDB",
+            "image": "https://gdb-engines.com/logos/ontotext-graphdb.png",
             "type": "RDF",
             "kind": "database",
             "category": "Enterprise",
@@ -1017,6 +1108,7 @@
           {
             "id": "db:oracle-graph",
             "label": "Oracle Graph",
+            "image": "https://gdb-engines.com/logos/oracle-graph.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -1028,6 +1120,7 @@
           {
             "id": "db:orientdb",
             "label": "OrientDB",
+            "image": "https://gdb-engines.com/logos/orientdb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -1039,6 +1132,7 @@
           {
             "id": "db:oxigraph",
             "label": "Oxigraph",
+            "image": "https://gdb-engines.com/logos/oxigraph.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1050,6 +1144,7 @@
           {
             "id": "db:oxirs",
             "label": "OxiRS",
+            "image": "https://gdb-engines.com/logos/oxirs.png",
             "type": "RDF",
             "kind": "library",
             "category": "Emerging",
@@ -1061,6 +1156,7 @@
           {
             "id": "db:pandadb",
             "label": "PandaDB",
+            "image": "https://gdb-engines.com/logos/pandadb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1072,6 +1168,7 @@
           {
             "id": "db:parliament",
             "label": "Parliament",
+            "image": "https://gdb-engines.com/logos/parliament.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1083,6 +1180,7 @@
           {
             "id": "db:pggraph",
             "label": "pgGraph",
+            "image": "https://gdb-engines.com/logos/pggraph.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -1094,6 +1192,7 @@
           {
             "id": "db:postgresql-sql-pgq",
             "label": "PostgreSQL SQL/PGQ",
+            "image": "https://gdb-engines.com/logos/postgresql-sql-pgq.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1105,6 +1204,7 @@
           {
             "id": "db:prometheux",
             "label": "Prometheux",
+            "image": "https://gdb-engines.com/logos/prometheux.png",
             "type": "Other",
             "kind": "query-engine",
             "category": "Growing",
@@ -1116,6 +1216,7 @@
           {
             "id": "db:puppygraph",
             "label": "PuppyGraph",
+            "image": "https://gdb-engines.com/logos/puppygraph.png",
             "type": "Property Graph",
             "kind": "query-engine",
             "category": "Growing",
@@ -1127,6 +1228,7 @@
           {
             "id": "db:qlever",
             "label": "QLever",
+            "image": "https://gdb-engines.com/logos/qlever.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1138,6 +1240,7 @@
           {
             "id": "db:quadstore",
             "label": "Quadstore",
+            "image": "https://gdb-engines.com/logos/quadstore.png",
             "type": "RDF",
             "kind": "embedded",
             "category": "Emerging",
@@ -1149,6 +1252,7 @@
           {
             "id": "db:quine",
             "label": "Quine",
+            "image": "https://gdb-engines.com/logos/quine.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1160,6 +1264,7 @@
           {
             "id": "db:raphtory",
             "label": "Raphtory",
+            "image": "https://gdb-engines.com/logos/raphtory.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1171,6 +1276,7 @@
           {
             "id": "db:rdf-trine",
             "label": "RDF::Trine",
+            "image": "https://gdb-engines.com/logos/rdf-trine.png",
             "type": "RDF",
             "kind": "library",
             "category": "Emerging",
@@ -1182,6 +1288,7 @@
           {
             "id": "db:rdflib",
             "label": "RDFLib",
+            "image": "https://gdb-engines.com/logos/rdflib.png",
             "type": "RDF",
             "kind": "library",
             "category": "Established",
@@ -1193,6 +1300,7 @@
           {
             "id": "db:rdfox",
             "label": "RDFox",
+            "image": "https://gdb-engines.com/logos/rdfox.png",
             "type": "RDF",
             "kind": "database",
             "category": "Enterprise",
@@ -1204,6 +1312,7 @@
           {
             "id": "db:recallgraph",
             "label": "RecallGraph",
+            "image": "https://gdb-engines.com/logos/recallgraph.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -1215,6 +1324,7 @@
           {
             "id": "db:redisgraph-falkordb",
             "label": "FalkorDB",
+            "image": "https://gdb-engines.com/logos/redisgraph-falkordb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -1226,6 +1336,7 @@
           {
             "id": "db:redland",
             "label": "Redland",
+            "image": "https://gdb-engines.com/logos/redland.png",
             "type": "RDF",
             "kind": "library",
             "category": "Established",
@@ -1237,6 +1348,7 @@
           {
             "id": "db:redstore",
             "label": "RedStore",
+            "image": "https://gdb-engines.com/logos/redstore.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1248,6 +1360,7 @@
           {
             "id": "db:relationalai",
             "label": "RelationalAI",
+            "image": "https://gdb-engines.com/logos/relationalai.png",
             "type": "Other",
             "kind": "database",
             "category": "Growing",
@@ -1259,6 +1372,7 @@
           {
             "id": "db:rocketgraph",
             "label": "Rocketgraph",
+            "image": "https://gdb-engines.com/logos/rocketgraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1270,6 +1384,7 @@
           {
             "id": "db:rushdb",
             "label": "RushDB",
+            "image": "https://gdb-engines.com/logos/rushdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1281,6 +1396,7 @@
           {
             "id": "db:ryugraph",
             "label": "RyuGraph",
+            "image": "https://gdb-engines.com/logos/ryugraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1292,6 +1408,7 @@
           {
             "id": "db:sap-hana",
             "label": "SAP Hana",
+            "image": "https://gdb-engines.com/logos/sap-hana.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -1303,6 +1420,7 @@
           {
             "id": "db:sones-graphdb",
             "label": "Sones GraphDB",
+            "image": "https://gdb-engines.com/logos/sones-graphdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1314,6 +1432,7 @@
           {
             "id": "db:spanner-graph",
             "label": "Google Cloud Spanner Graph",
+            "image": "https://gdb-engines.com/logos/spanner-graph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Enterprise",
@@ -1325,6 +1444,7 @@
           {
             "id": "db:sparkledb",
             "label": "SparkleDB",
+            "image": "https://gdb-engines.com/logos/sparkledb.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1336,6 +1456,7 @@
           {
             "id": "db:sparksee",
             "label": "Sparksee",
+            "image": "https://gdb-engines.com/logos/sparksee.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -1347,6 +1468,7 @@
           {
             "id": "db:stardog",
             "label": "Stardog",
+            "image": "https://gdb-engines.com/logos/stardog.png",
             "type": "RDF",
             "kind": "database",
             "category": "Enterprise",
@@ -1358,6 +1480,7 @@
           {
             "id": "db:stellardb",
             "label": "StellarDB",
+            "image": "https://gdb-engines.com/logos/stellardb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1369,6 +1492,7 @@
           {
             "id": "db:strabon",
             "label": "Strabon",
+            "image": "https://gdb-engines.com/logos/strabon.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1380,6 +1504,7 @@
           {
             "id": "db:stromadb",
             "label": "StromaDB",
+            "image": "https://gdb-engines.com/logos/stromadb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1391,6 +1516,7 @@
           {
             "id": "db:surrealdb",
             "label": "SurrealDB",
+            "image": "https://gdb-engines.com/logos/surrealdb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Growing",
@@ -1402,6 +1528,7 @@
           {
             "id": "db:tao",
             "label": "TAO",
+            "image": "https://gdb-engines.com/logos/tao.png",
             "type": "Other",
             "kind": "database",
             "category": "Established",
@@ -1413,6 +1540,7 @@
           {
             "id": "db:tentris",
             "label": "Tentris",
+            "image": "https://gdb-engines.com/logos/tentris.png",
             "type": "RDF",
             "kind": "database",
             "category": "Emerging",
@@ -1424,6 +1552,7 @@
           {
             "id": "db:terminusdb",
             "label": "TerminusDB",
+            "image": "https://gdb-engines.com/logos/terminusdb.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Emerging",
@@ -1435,6 +1564,7 @@
           {
             "id": "db:tigergraph",
             "label": "TigerGraph",
+            "image": "https://gdb-engines.com/logos/tigergraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -1446,6 +1576,7 @@
           {
             "id": "db:tinkergraph",
             "label": "TinkerGraph",
+            "image": "https://gdb-engines.com/logos/tinkergraph.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Established",
@@ -1457,6 +1588,7 @@
           {
             "id": "db:traverse",
             "label": "Traverse",
+            "image": "https://gdb-engines.com/logos/traverse.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1468,6 +1600,7 @@
           {
             "id": "db:triblespace",
             "label": "TribleSpace",
+            "image": "https://gdb-engines.com/logos/triblespace.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -1479,6 +1612,7 @@
           {
             "id": "db:tugraph",
             "label": "TuGraph",
+            "image": "https://gdb-engines.com/logos/tugraph.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Established",
@@ -1490,6 +1624,7 @@
           {
             "id": "db:turbolynx",
             "label": "TurboLynx",
+            "image": "https://gdb-engines.com/logos/turbolynx.png",
             "type": "Property Graph",
             "kind": "embedded",
             "category": "Emerging",
@@ -1501,6 +1636,7 @@
           {
             "id": "db:turingdb",
             "label": "TuringDB",
+            "image": "https://gdb-engines.com/logos/turingdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1512,6 +1648,7 @@
           {
             "id": "db:typedb",
             "label": "TypeDB",
+            "image": "https://gdb-engines.com/logos/typedb.png",
             "type": "Other",
             "kind": "database",
             "category": "Growing",
@@ -1523,6 +1660,7 @@
           {
             "id": "db:ultipa",
             "label": "Ultipa",
+            "image": "https://gdb-engines.com/logos/ultipa.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Growing",
@@ -1534,6 +1672,7 @@
           {
             "id": "db:velocitygraph",
             "label": "VelocityGraph",
+            "image": "https://gdb-engines.com/logos/velocitygraph.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -1545,6 +1684,7 @@
           {
             "id": "db:virtuoso",
             "label": "Virtuoso",
+            "image": "https://gdb-engines.com/logos/virtuoso.png",
             "type": "Multiple",
             "kind": "database",
             "category": "Enterprise",
@@ -1556,6 +1696,7 @@
           {
             "id": "db:weaver",
             "label": "Weaver",
+            "image": "https://gdb-engines.com/logos/weaver.png",
             "type": "Other",
             "kind": "database",
             "category": "Emerging",
@@ -1567,6 +1708,7 @@
           {
             "id": "db:youtrackdb",
             "label": "YouTrackDB",
+            "image": "https://gdb-engines.com/logos/youtrackdb.png",
             "type": "Property Graph",
             "kind": "database",
             "category": "Emerging",
@@ -1578,6 +1720,7 @@
           {
             "id": "db:yugabytedb-mage",
             "label": "YugabyteDB MAGE",
+            "image": "https://gdb-engines.com/logos/yugabytedb-mage.png",
             "type": "Property Graph",
             "kind": "extension",
             "category": "Emerging",
@@ -1589,6 +1732,7 @@
           {
             "id": "db:zipg",
             "label": "ZipG",
+            "image": "https://gdb-engines.com/logos/zipg.png",
             "type": "Other",
             "kind": "embedded",
             "category": "Emerging",
@@ -2031,12 +2175,12 @@
           },
           {
             "source": "db:data-graphs",
-            "target": "db:galaxybase",
-            "similarity": 0.5
+            "target": "db:nodedb",
+            "similarity": 0.5556
           },
           {
             "source": "db:data-graphs",
-            "target": "db:memgql",
+            "target": "db:galaxybase",
             "similarity": 0.5
           },
           {
@@ -2550,6 +2694,11 @@
             "similarity": 0.8571
           },
           {
+            "source": "db:data-graphs",
+            "target": "db:memgql",
+            "similarity": 0.5
+          },
+          {
             "source": "db:faunadb",
             "target": "db:memgql",
             "similarity": 0.3333
@@ -2646,18 +2795,13 @@
           },
           {
             "source": "db:nodedb",
-            "target": "db:rocketgraph",
-            "similarity": 0.5
-          },
-          {
-            "source": "db:nodedb",
-            "target": "db:omnigraph",
+            "target": "db:stellardb",
             "similarity": 0.4444
           },
           {
-            "source": "db:nodedb",
-            "target": "db:ongdb",
-            "similarity": 0.4444
+            "source": "db:lance-graph",
+            "target": "db:nodedb",
+            "similarity": 0.4
           },
           {
             "source": "db:nornicdb",
@@ -2860,7 +3004,7 @@
             "similarity": 0.5
           },
           {
-            "source": "db:nodedb",
+            "source": "db:nornicdb",
             "target": "db:raphtory",
             "similarity": 0.4444
           },
@@ -3224,6 +3368,14 @@
           "id": "degree"
         },
         "resultType": "num"
+      },
+      {
+        "channel": "image",
+        "source": {
+          "kind": "field",
+          "id": "image"
+        },
+        "resultType": "cat"
       },
       {
         "channel": "color",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -3378,15 +3378,6 @@
         "resultType": "cat"
       },
       {
-        "channel": "hull",
-        "source": {
-          "kind": "field",
-          "id": "type"
-        },
-        "resultType": "cat",
-        "enabled": false
-      },
-      {
         "channel": "color",
         "source": {
           "kind": "field",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -323,7 +323,7 @@
             "status": "active",
             "license": "MIT",
             "implementationLanguage": "TypeScript",
-            "queryLanguages": "Gremlin, Cypher"
+            "queryLanguages": "Gremlin, openCypher"
           },
           {
             "id": "db:cogdb",
@@ -575,7 +575,7 @@
             "status": "active",
             "license": "BSD-3-Clause",
             "implementationLanguage": "Python",
-            "queryLanguages": "GFQL, Cypher"
+            "queryLanguages": "GFQL, openCypher"
           },
           {
             "id": "db:google-cayley",
@@ -599,7 +599,7 @@
             "status": "active",
             "license": "Apache-2.0",
             "implementationLanguage": "Rust",
-            "queryLanguages": "GQL, Cypher, SPARQL, Gremlin, GraphQL, SQL/PGQ"
+            "queryLanguages": "GQL, openCypher, SPARQL, Gremlin, GraphQL, SQL/PGQ"
           },
           {
             "id": "db:graph-engine",
@@ -1019,7 +1019,7 @@
             "status": "active",
             "license": "Apache-2.0",
             "implementationLanguage": "C++",
-            "queryLanguages": "Cypher"
+            "queryLanguages": "openCypher"
           },
           {
             "id": "db:nodedb",
@@ -1043,7 +1043,7 @@
             "status": "active",
             "license": "MIT",
             "implementationLanguage": "Go",
-            "queryLanguages": "Cypher, GraphQL"
+            "queryLanguages": "openCypher, GraphQL"
           },
           {
             "id": "db:objectivity-db",
@@ -1379,7 +1379,7 @@
             "status": "active",
             "license": "Proprietary",
             "implementationLanguage": null,
-            "queryLanguages": "Cypher"
+            "queryLanguages": "openCypher"
           },
           {
             "id": "db:rushdb",
@@ -2121,14 +2121,14 @@
             "similarity": 0.625
           },
           {
-            "source": "db:codemix-graph",
-            "target": "db:nornicdb",
-            "similarity": 0.4
+            "source": "db:bighorn",
+            "target": "db:codemix-graph",
+            "similarity": 0.4444
           },
           {
             "source": "db:codemix-graph",
-            "target": "db:rocketgraph",
-            "similarity": 0.3333
+            "target": "db:graphqlite",
+            "similarity": 0.4444
           },
           {
             "source": "db:cogdb",
@@ -2236,9 +2236,9 @@
             "similarity": 0.4444
           },
           {
-            "source": "db:dozerdb",
-            "target": "db:rocketgraph",
-            "similarity": 0.375
+            "source": "db:bitsy",
+            "target": "db:dozerdb",
+            "similarity": 0.3333
           },
           {
             "source": "db:bighorn",
@@ -2292,7 +2292,7 @@
           },
           {
             "source": "db:falkordblite",
-            "target": "db:turbolynx",
+            "target": "db:neug",
             "similarity": 0.5
           },
           {
@@ -2382,6 +2382,11 @@
           },
           {
             "source": "db:galaxybase",
+            "target": "db:rocketgraph",
+            "similarity": 1
+          },
+          {
+            "source": "db:galaxybase",
             "target": "db:stellardb",
             "similarity": 0.8333
           },
@@ -2391,24 +2396,19 @@
             "similarity": 0.7143
           },
           {
-            "source": "db:galaxybase",
-            "target": "db:rocketgraph",
-            "similarity": 0.6667
-          },
-          {
             "source": "db:gfql",
             "target": "db:puppygraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:falkordblite",
+            "target": "db:gfql",
             "similarity": 0.3
           },
           {
             "source": "db:gfql",
-            "target": "db:prometheux",
-            "similarity": 0.2
-          },
-          {
-            "source": "db:gfql",
-            "target": "db:rocketgraph",
-            "similarity": 0.2
+            "target": "db:ladybugdb",
+            "similarity": 0.3
           },
           {
             "source": "db:apache-rya",
@@ -2423,16 +2423,16 @@
           {
             "source": "db:data-graphs",
             "target": "db:grafeo",
-            "similarity": 0.3846
+            "similarity": 0.5
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "db:grafeo",
+            "similarity": 0.4286
           },
           {
             "source": "db:grafeo",
             "target": "db:millenniumdb",
-            "similarity": 0.3846
-          },
-          {
-            "source": "db:grafeo",
-            "target": "db:terminusdb",
             "similarity": 0.3846
           },
           {
@@ -2791,19 +2791,19 @@
             "similarity": 0.5556
           },
           {
-            "source": "db:agdb",
-            "target": "db:neug",
-            "similarity": 0.5
-          },
-          {
             "source": "db:bighorn",
             "target": "db:neug",
-            "similarity": 0.5
+            "similarity": 0.7143
           },
           {
-            "source": "db:bitsy",
+            "source": "db:kuzu",
             "target": "db:neug",
-            "similarity": 0.5
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:neug",
+            "target": "db:turbolynx",
+            "similarity": 0.7143
           },
           {
             "source": "db:nodedb",
@@ -2817,18 +2817,18 @@
           },
           {
             "source": "db:nornicdb",
-            "target": "db:rocketgraph",
+            "target": "db:ryugraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:nornicdb",
             "similarity": 0.5
           },
           {
             "source": "db:nornicdb",
-            "target": "db:omnigraph",
-            "similarity": 0.4444
-          },
-          {
-            "source": "db:nornicdb",
-            "target": "db:ongdb",
-            "similarity": 0.4444
+            "target": "db:rocketgraph",
+            "similarity": 0.5
           },
           {
             "source": "db:omnigraph",
@@ -2839,11 +2839,6 @@
             "source": "db:kglite",
             "target": "db:omnigraph",
             "similarity": 0.625
-          },
-          {
-            "source": "db:ongdb",
-            "target": "db:rocketgraph",
-            "similarity": 0.5714
           },
           {
             "source": "db:graphflow",
@@ -2981,11 +2976,6 @@
             "similarity": 0.4444
           },
           {
-            "source": "db:galaxybase",
-            "target": "db:puppygraph",
-            "similarity": 0.375
-          },
-          {
             "source": "db:apache-rya",
             "target": "db:qlever",
             "similarity": 0.7143
@@ -3001,9 +2991,9 @@
             "similarity": 0.5
           },
           {
-            "source": "db:graphflow",
-            "target": "db:quine",
-            "similarity": 0.4444
+            "source": "db:quine",
+            "target": "db:rocketgraph",
+            "similarity": 0.5
           },
           {
             "source": "db:omnigraph",
@@ -3113,7 +3103,12 @@
           {
             "source": "db:rocketgraph",
             "target": "db:stellardb",
-            "similarity": 0.5714
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:rocketgraph",
+            "target": "db:traverse",
+            "similarity": 0.7143
           },
           {
             "source": "db:omnigraph",
@@ -3249,6 +3244,11 @@
             "source": "db:ibm-system-g",
             "target": "db:tao",
             "similarity": 0.5
+          },
+          {
+            "source": "db:grafeo",
+            "target": "db:terminusdb",
+            "similarity": 0.3846
           },
           {
             "source": "db:google-cayley",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -3378,6 +3378,15 @@
         "resultType": "cat"
       },
       {
+        "channel": "hull",
+        "source": {
+          "kind": "field",
+          "id": "type"
+        },
+        "resultType": "cat",
+        "enabled": false
+      },
+      {
         "channel": "color",
         "source": {
           "kind": "field",

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -1,0 +1,3247 @@
+{
+  "info": {
+    "version": 1,
+    "name": "Database similarity"
+  },
+  "datasets": [
+    {
+      "id": "main",
+      "graph": {
+        "directed": false,
+        "multigraph": false,
+        "graph": {
+          "name": "Database similarity"
+        },
+        "nodes": [
+          {
+            "id": "db:4store",
+            "label": "4store",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "GPL-3.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:aerospike",
+            "label": "Aerospike Graph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "AGPL-3.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:agdb",
+            "label": "agdb",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:agensgraph",
+            "label": "AgensGraph",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Growing",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "openCypher, SQL"
+          },
+          {
+            "id": "db:akutan",
+            "label": "Akutan",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Go",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:alibaba-gdb",
+            "label": "Alibaba GDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": ""
+          },
+          {
+            "id": "db:allegrograph",
+            "label": "AllegroGraph",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Common Lisp",
+            "queryLanguages": "SPARQL, Prolog"
+          },
+          {
+            "id": "db:altair-graph-lakehouse",
+            "label": "Altair Graph Lakehouse",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL, openCypher"
+          },
+          {
+            "id": "db:apache-age",
+            "label": "Apache AGE",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "openCypher, SQL"
+          },
+          {
+            "id": "db:apache-giraph",
+            "label": "Apache Giraph",
+            "type": "Property Graph",
+            "kind": "query-engine",
+            "category": "Established",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Java API"
+          },
+          {
+            "id": "db:apache-hugegraph",
+            "label": "Apache HugeGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin, openCypher"
+          },
+          {
+            "id": "db:apache-jena-fuseki",
+            "label": "Apache Jena Fuseki",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:apache-rya",
+            "label": "Apache Rya",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:arangodb",
+            "label": "ArangoDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "BSL-1.1",
+            "implementationLanguage": "C++",
+            "queryLanguages": "AQL"
+          },
+          {
+            "id": "db:arcadedb",
+            "label": "ArcadeDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SQL, openCypher, Gremlin, GraphQL"
+          },
+          {
+            "id": "db:atomic-server",
+            "label": "Atomic Server",
+            "type": "Other",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:attean",
+            "label": "Attean",
+            "type": "RDF",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Artistic-2.0",
+            "implementationLanguage": "Perl",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:bangdb",
+            "label": "BangDB",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:bighorn",
+            "label": "Bighorn",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:bigquery-graph",
+            "label": "Google Cloud BigQuery Graph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "GQL, SQL/PGQ"
+          },
+          {
+            "id": "db:bitsy",
+            "label": "Bitsy",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:blazegraph",
+            "label": "BlazeGraph",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Established",
+            "status": "inactive",
+            "license": "GPL-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL, Gremlin"
+          },
+          {
+            "id": "db:brightstardb",
+            "label": "BrightstarDB",
+            "type": "RDF",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "MIT",
+            "implementationLanguage": "C#",
+            "queryLanguages": "SPARQL, LINQ"
+          },
+          {
+            "id": "db:bytegraph",
+            "label": "ByteGraph",
+            "type": "Other",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "inactive",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:chronograph",
+            "label": "ChronoGraph",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "AGPL-3.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:codemix-graph",
+            "label": "CodeMix Graph",
+            "type": "Property Graph",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "TypeScript",
+            "queryLanguages": "Gremlin, Cypher"
+          },
+          {
+            "id": "db:cogdb",
+            "label": "CogDB",
+            "type": "RDF",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Python",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:comunica",
+            "label": "Comunica",
+            "type": "RDF",
+            "kind": "query-engine",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "TypeScript",
+            "queryLanguages": "SPARQL, GraphQL"
+          },
+          {
+            "id": "db:cosmos-db",
+            "label": "Cosmos DB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Gremlin, SQL"
+          },
+          {
+            "id": "db:cray-graph-engine",
+            "label": "Cray Graph Engine",
+            "type": "Other",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "deprecated",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:data-graphs",
+            "label": "Data Graphs",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "openCypher, GQL"
+          },
+          {
+            "id": "db:datastax-enterprise",
+            "label": "DataStax Enterprise",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin, CQL"
+          },
+          {
+            "id": "db:dgraph",
+            "label": "Dgraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Go",
+            "queryLanguages": "DQL, GraphQL"
+          },
+          {
+            "id": "db:dozerdb",
+            "label": "DozerDB",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "active",
+            "license": "GPL-3.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Cypher"
+          },
+          {
+            "id": "db:duckpgq",
+            "label": "DuckPGQ",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SQL/PGQ"
+          },
+          {
+            "id": "db:dydra",
+            "label": "Dydra",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "SPARQL, GraphQL"
+          },
+          {
+            "id": "db:eclipse-rdf4j",
+            "label": "Eclipse RDF4J",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:fabric-graph",
+            "label": "Microsoft Fabric Graph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "GQL"
+          },
+          {
+            "id": "db:falkordblite",
+            "label": "FalkorDBLite",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "SSPL-1.0",
+            "implementationLanguage": "Python",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:faunadb",
+            "label": "FaunaDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "deprecated",
+            "license": "Proprietary",
+            "implementationLanguage": "Scala",
+            "queryLanguages": "FQL, GraphQL"
+          },
+          {
+            "id": "db:flockdb",
+            "label": "FlockDB",
+            "type": "Other",
+            "kind": "database",
+            "category": "Established",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Scala",
+            "queryLanguages": "Thrift API"
+          },
+          {
+            "id": "db:fluree",
+            "label": "Fluree",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "EPL-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "FlureeQL, SPARQL, GraphQL"
+          },
+          {
+            "id": "db:frogql",
+            "label": "froGQL",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "GQL"
+          },
+          {
+            "id": "db:g-tran",
+            "label": "G-Tran",
+            "type": "Other",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:gaffer",
+            "label": "Gaffer",
+            "type": "Other",
+            "kind": "query-engine",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:galaxybase",
+            "label": "GalaxyBase",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:gfql",
+            "label": "GFQL",
+            "type": "Property Graph",
+            "kind": "query-engine",
+            "category": "Growing",
+            "status": "active",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "Python",
+            "queryLanguages": "GFQL, Cypher"
+          },
+          {
+            "id": "db:google-cayley",
+            "label": "Google Cayley",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Go",
+            "queryLanguages": "Gizmo, GraphQL, MQL"
+          },
+          {
+            "id": "db:grafeo",
+            "label": "Grafeo",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "GQL, Cypher, SPARQL, Gremlin, GraphQL, SQL/PGQ"
+          },
+          {
+            "id": "db:graph-engine",
+            "label": "Graph Engine",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "inactive",
+            "license": "MIT",
+            "implementationLanguage": "C#",
+            "queryLanguages": "LIKQ"
+          },
+          {
+            "id": "db:graphbase",
+            "label": "GraphBase",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "GraphQL"
+          },
+          {
+            "id": "db:graphflow",
+            "label": "Graphflow",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "deprecated",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:graphlite",
+            "label": "GraphLite",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "GQL"
+          },
+          {
+            "id": "db:graphqlite",
+            "label": "GraphQLite",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:graphscope",
+            "label": "GraphScope",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Gremlin, openCypher"
+          },
+          {
+            "id": "db:grust",
+            "label": "Grust",
+            "type": "Property Graph",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:gstore",
+            "label": "gStore",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:gun",
+            "label": "GUN",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "JavaScript",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:halyard",
+            "label": "Halyard",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:helixdb",
+            "label": "HelixDB",
+            "type": "Other",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "AGPL-3.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "HelixQL"
+          },
+          {
+            "id": "db:hgraphdb",
+            "label": "HGraphDB",
+            "type": "Other",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:huawei-ges",
+            "label": "Huawei Graph Engine Service",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Gremlin, openCypher"
+          },
+          {
+            "id": "db:hypergraphdb",
+            "label": "HyperGraphDB",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Java API"
+          },
+          {
+            "id": "db:ibm-system-g",
+            "label": "IBM System G",
+            "type": "Other",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "deprecated",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:infinitegraph",
+            "label": "InfiniteGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "inactive",
+            "license": "Proprietary",
+            "implementationLanguage": "Java",
+            "queryLanguages": "DO Query Language"
+          },
+          {
+            "id": "db:janusgraph",
+            "label": "JanusGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:katanagraph",
+            "label": "KatanaGraph",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:kglite",
+            "label": "KGLite",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "openCypher, Custom API"
+          },
+          {
+            "id": "db:kinetica",
+            "label": "Kinetica",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SQL"
+          },
+          {
+            "id": "db:kuzu",
+            "label": "Kuzu",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "deprecated",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:ladybugdb",
+            "label": "LadybugDB",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Growing",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:lance-graph",
+            "label": "Lance Graph",
+            "type": "Property Graph",
+            "kind": "query-engine",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "SQL, openCypher"
+          },
+          {
+            "id": "db:livegraph",
+            "label": "LiveGraph",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:marklogic",
+            "label": "MarkLogic",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL, XQuery, SQL"
+          },
+          {
+            "id": "db:marmotta-kiwi",
+            "label": "Apache Marmotta KiWi",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:memgql",
+            "label": "MemGQL",
+            "type": "Multiple",
+            "kind": "query-engine",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "GQL"
+          },
+          {
+            "id": "db:memgraph",
+            "label": "Memgraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "BSL-1.1",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:millenniumdb",
+            "label": "MillenniumDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "GPL-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "GQL, SPARQL"
+          },
+          {
+            "id": "db:minigraf",
+            "label": "Minigraf",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT OR Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Datalog"
+          },
+          {
+            "id": "db:mulgara",
+            "label": "Mulgara",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL, iTQL"
+          },
+          {
+            "id": "db:nebulagraph",
+            "label": "NebulaGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "nGQL"
+          },
+          {
+            "id": "db:neo4j",
+            "label": "Neo4j",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "GPL-3.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Cypher, GQL"
+          },
+          {
+            "id": "db:neptune",
+            "label": "Neptune",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Gremlin, SPARQL, openCypher"
+          },
+          {
+            "id": "db:neug",
+            "label": "NeuG",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Cypher"
+          },
+          {
+            "id": "db:nodedb",
+            "label": "NodeDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "BUSL-1.1",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Cypher, SQL"
+          },
+          {
+            "id": "db:nornicdb",
+            "label": "NornicDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Go",
+            "queryLanguages": "Cypher, GraphQL"
+          },
+          {
+            "id": "db:objectivity-db",
+            "label": "Objectivity/DB",
+            "type": "Other",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "inactive",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "DO Query Language"
+          },
+          {
+            "id": "db:omnigraph",
+            "label": "OmniGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:ongdb",
+            "label": "ONgDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "GPL-3.0 OR AGPL-3.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Cypher"
+          },
+          {
+            "id": "db:ontop",
+            "label": "Ontop",
+            "type": "RDF",
+            "kind": "query-engine",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:ontotext-graphdb",
+            "label": "Ontotext GraphDB",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:oracle-graph",
+            "label": "Oracle Graph",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SQL/PGQ, PGQL, SPARQL"
+          },
+          {
+            "id": "db:orientdb",
+            "label": "OrientDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SQL, Gremlin"
+          },
+          {
+            "id": "db:oxigraph",
+            "label": "Oxigraph",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0 OR MIT",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:oxirs",
+            "label": "OxiRS",
+            "type": "RDF",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:pandadb",
+            "label": "PandaDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Scala",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:parliament",
+            "label": "Parliament",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:pggraph",
+            "label": "pgGraph",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "SQL"
+          },
+          {
+            "id": "db:postgresql-sql-pgq",
+            "label": "PostgreSQL SQL/PGQ",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "PostgreSQL",
+            "implementationLanguage": "C",
+            "queryLanguages": "SQL/PGQ"
+          },
+          {
+            "id": "db:prometheux",
+            "label": "Prometheux",
+            "type": "Other",
+            "kind": "query-engine",
+            "category": "Growing",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Vadalog"
+          },
+          {
+            "id": "db:puppygraph",
+            "label": "PuppyGraph",
+            "type": "Property Graph",
+            "kind": "query-engine",
+            "category": "Growing",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Gremlin, openCypher"
+          },
+          {
+            "id": "db:qlever",
+            "label": "QLever",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:quadstore",
+            "label": "Quadstore",
+            "type": "RDF",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "TypeScript",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:quine",
+            "label": "Quine",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT + Commons Clause",
+            "implementationLanguage": "Scala",
+            "queryLanguages": "openCypher, Gremlin"
+          },
+          {
+            "id": "db:raphtory",
+            "label": "Raphtory",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "GPL-3.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "GraphQL"
+          },
+          {
+            "id": "db:rdf-trine",
+            "label": "RDF::Trine",
+            "type": "RDF",
+            "kind": "library",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Artistic-2.0",
+            "implementationLanguage": "Perl",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:rdflib",
+            "label": "RDFLib",
+            "type": "RDF",
+            "kind": "library",
+            "category": "Established",
+            "status": "active",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "Python",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:rdfox",
+            "label": "RDFox",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:recallgraph",
+            "label": "RecallGraph",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "deprecated",
+            "license": "Apache-2.0",
+            "implementationLanguage": "JavaScript",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:redisgraph-falkordb",
+            "label": "FalkorDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "SSPL-1.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:redland",
+            "label": "Redland",
+            "type": "RDF",
+            "kind": "library",
+            "category": "Established",
+            "status": "inactive",
+            "license": "LGPL-2.1",
+            "implementationLanguage": "C",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:redstore",
+            "label": "RedStore",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "GPL-3.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:relationalai",
+            "label": "RelationalAI",
+            "type": "Other",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Julia",
+            "queryLanguages": "Rel, SQL"
+          },
+          {
+            "id": "db:rocketgraph",
+            "label": "Rocketgraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "Cypher"
+          },
+          {
+            "id": "db:rushdb",
+            "label": "RushDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "ELv2",
+            "implementationLanguage": "TypeScript",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:ryugraph",
+            "label": "RyuGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:sap-hana",
+            "label": "SAP Hana",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SQL, openCypher, GraphScript"
+          },
+          {
+            "id": "db:sones-graphdb",
+            "label": "Sones GraphDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "AGPL-3.0",
+            "implementationLanguage": "C#",
+            "queryLanguages": "GQL (Sones)"
+          },
+          {
+            "id": "db:spanner-graph",
+            "label": "Google Cloud Spanner Graph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "GQL, SQL/PGQ"
+          },
+          {
+            "id": "db:sparkledb",
+            "label": "SparkleDB",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:sparksee",
+            "label": "Sparksee",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:stardog",
+            "label": "Stardog",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL, SQL, GraphQL"
+          },
+          {
+            "id": "db:stellardb",
+            "label": "StellarDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "openCypher, SQL"
+          },
+          {
+            "id": "db:strabon",
+            "label": "Strabon",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "MPL-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "SPARQL, stSPARQL, GeoSPARQL"
+          },
+          {
+            "id": "db:stromadb",
+            "label": "StromaDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Elastic-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:surrealdb",
+            "label": "SurrealDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "BSL-1.1",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "SurrealQL, GraphQL, GQL"
+          },
+          {
+            "id": "db:tao",
+            "label": "TAO",
+            "type": "Other",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "TAO API"
+          },
+          {
+            "id": "db:tentris",
+            "label": "Tentris",
+            "type": "RDF",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "SPARQL"
+          },
+          {
+            "id": "db:terminusdb",
+            "label": "TerminusDB",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Prolog",
+            "queryLanguages": "WOQL, GraphQL"
+          },
+          {
+            "id": "db:tigergraph",
+            "label": "TigerGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "C++",
+            "queryLanguages": "GSQL"
+          },
+          {
+            "id": "db:tinkergraph",
+            "label": "TinkerGraph",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin"
+          },
+          {
+            "id": "db:traverse",
+            "label": "Traverse",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "openCypher, GQL"
+          },
+          {
+            "id": "db:triblespace",
+            "label": "TribleSpace",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT OR Apache-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:tugraph",
+            "label": "TuGraph",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Established",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher, GQL"
+          },
+          {
+            "id": "db:turbolynx",
+            "label": "TurboLynx",
+            "type": "Property Graph",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "active",
+            "license": "MIT",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:turingdb",
+            "label": "TuringDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "BSL-1.1",
+            "implementationLanguage": "C++",
+            "queryLanguages": "openCypher"
+          },
+          {
+            "id": "db:typedb",
+            "label": "TypeDB",
+            "type": "Other",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "MPL-2.0",
+            "implementationLanguage": "Rust",
+            "queryLanguages": "TypeQL"
+          },
+          {
+            "id": "db:ultipa",
+            "label": "Ultipa",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Growing",
+            "status": "active",
+            "license": "Proprietary",
+            "implementationLanguage": null,
+            "queryLanguages": "UQL"
+          },
+          {
+            "id": "db:velocitygraph",
+            "label": "VelocityGraph",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "MIT",
+            "implementationLanguage": "C#",
+            "queryLanguages": "LINQ"
+          },
+          {
+            "id": "db:virtuoso",
+            "label": "Virtuoso",
+            "type": "Multiple",
+            "kind": "database",
+            "category": "Enterprise",
+            "status": "active",
+            "license": "GPL-2.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "SQL, SPARQL"
+          },
+          {
+            "id": "db:weaver",
+            "label": "Weaver",
+            "type": "Other",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": "BSD-3-Clause",
+            "implementationLanguage": "C++",
+            "queryLanguages": "Custom API"
+          },
+          {
+            "id": "db:youtrackdb",
+            "label": "YouTrackDB",
+            "type": "Property Graph",
+            "kind": "database",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "Java",
+            "queryLanguages": "Gremlin, SQL"
+          },
+          {
+            "id": "db:yugabytedb-mage",
+            "label": "YugabyteDB MAGE",
+            "type": "Property Graph",
+            "kind": "extension",
+            "category": "Emerging",
+            "status": "active",
+            "license": "Apache-2.0",
+            "implementationLanguage": "C",
+            "queryLanguages": "openCypher, SQL"
+          },
+          {
+            "id": "db:zipg",
+            "label": "ZipG",
+            "type": "Other",
+            "kind": "embedded",
+            "category": "Emerging",
+            "status": "inactive",
+            "license": null,
+            "implementationLanguage": "Java",
+            "queryLanguages": "Custom API"
+          }
+        ],
+        "links": [
+          {
+            "source": "db:4store",
+            "target": "db:redstore",
+            "similarity": 1
+          },
+          {
+            "source": "db:4store",
+            "target": "db:sparkledb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:4store",
+            "target": "db:apache-rya",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:aerospike",
+            "target": "db:huawei-ges",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:aerospike",
+            "target": "db:alibaba-gdb",
+            "similarity": 0.4286
+          },
+          {
+            "source": "db:aerospike",
+            "target": "db:fabric-graph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:graphlite",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:grust",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:kglite",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:agensgraph",
+            "target": "db:apache-age",
+            "similarity": 0.75
+          },
+          {
+            "source": "db:agensgraph",
+            "target": "db:yugabytedb-mage",
+            "similarity": 0.75
+          },
+          {
+            "source": "db:agensgraph",
+            "target": "db:graphqlite",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:akutan",
+            "target": "db:google-cayley",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:akutan",
+            "target": "db:apache-rya",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:akutan",
+            "target": "db:halyard",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:fabric-graph",
+            "similarity": 0.8
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:graphbase",
+            "similarity": 0.8
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:bigquery-graph",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:allegrograph",
+            "target": "db:sparkledb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:allegrograph",
+            "target": "db:apache-jena-fuseki",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:allegrograph",
+            "target": "db:dydra",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "db:rdfox",
+            "similarity": 0.8571
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "db:cray-graph-engine",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "db:ontotext-graphdb",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-age",
+            "target": "db:yugabytedb-mage",
+            "similarity": 0.75
+          },
+          {
+            "source": "db:apache-age",
+            "target": "db:graphqlite",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:apache-giraph",
+            "target": "db:gaffer",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-giraph",
+            "target": "db:janusgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-giraph",
+            "target": "db:ontop",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:janusgraph",
+            "similarity": 0.8571
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:graphflow",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:tinkergraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:apache-rya",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:eclipse-rdf4j",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:halyard",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:halyard",
+            "similarity": 1
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:marmotta-kiwi",
+            "similarity": 1
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:mulgara",
+            "similarity": 0.8571
+          },
+          {
+            "source": "db:arangodb",
+            "target": "db:memgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:arangodb",
+            "target": "db:marklogic",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:arangodb",
+            "target": "db:sap-hana",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "db:orientdb",
+            "similarity": 0.6
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:arcadedb",
+            "similarity": 0.4545
+          },
+          {
+            "source": "db:arcadedb",
+            "target": "db:graphscope",
+            "similarity": 0.4545
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:omnigraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:helixdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:stromadb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:attean",
+            "target": "db:rdf-trine",
+            "similarity": 1
+          },
+          {
+            "source": "db:attean",
+            "target": "db:oxirs",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:attean",
+            "target": "db:sparkledb",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:bangdb",
+            "target": "db:katanagraph",
+            "similarity": 1
+          },
+          {
+            "source": "db:bangdb",
+            "target": "db:bighorn",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bangdb",
+            "target": "db:kuzu",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:kuzu",
+            "similarity": 1
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:turbolynx",
+            "similarity": 1
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:ladybugdb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:bigquery-graph",
+            "target": "db:spanner-graph",
+            "similarity": 1
+          },
+          {
+            "source": "db:bigquery-graph",
+            "target": "db:fabric-graph",
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:chronograph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:tinkergraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:youtrackdb",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:blazegraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:blazegraph",
+            "target": "db:eclipse-rdf4j",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:blazegraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "db:quadstore",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "db:cogdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "db:velocitygraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:ibm-system-g",
+            "similarity": 1
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:cray-graph-engine",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:objectivity-db",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:chronograph",
+            "target": "db:tinkergraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:chronograph",
+            "target": "db:youtrackdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:codemix-graph",
+            "target": "db:nornicdb",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:codemix-graph",
+            "target": "db:rocketgraph",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:codemix-graph",
+            "similarity": 0.3
+          },
+          {
+            "source": "db:cogdb",
+            "target": "db:quadstore",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:cogdb",
+            "target": "db:kglite",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:comunica",
+            "target": "db:quadstore",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:comunica",
+            "target": "db:dydra",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:brightstardb",
+            "target": "db:comunica",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:neptune",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:orientdb",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:marklogic",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "db:ibm-system-g",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "db:objectivity-db",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:traverse",
+            "similarity": 0.75
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:galaxybase",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:memgql",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:datastax-enterprise",
+            "target": "db:janusgraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:datastax-enterprise",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:datastax-enterprise",
+            "target": "db:huawei-ges",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:dgraph",
+            "target": "db:graphbase",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:dgraph",
+            "target": "db:nornicdb",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:dgraph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:dozerdb",
+            "target": "db:ongdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:dozerdb",
+            "target": "db:neo4j",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:dozerdb",
+            "target": "db:rocketgraph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:duckpgq",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:duckpgq",
+            "target": "db:graphqlite",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:duckpgq",
+            "target": "db:kuzu",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:sparkledb",
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:tentris",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:stardog",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:eclipse-rdf4j",
+            "target": "db:parliament",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:spanner-graph",
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:falkordblite",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:falkordblite",
+            "target": "db:kuzu",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:falkordblite",
+            "target": "db:turbolynx",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:faunadb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:faunadb",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:faunadb",
+            "target": "db:terminusdb",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:flockdb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:flockdb",
+            "target": "db:g-tran",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:flockdb",
+            "target": "db:gaffer",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:fluree",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:fluree",
+            "target": "db:oxigraph",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:fluree",
+            "target": "db:stardog",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:frogql",
+            "target": "db:graphlite",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:frogql",
+            "target": "db:kglite",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:frogql",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:g-tran",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:g-tran",
+            "target": "db:hgraphdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:g-tran",
+            "target": "db:ibm-system-g",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:gaffer",
+            "target": "db:ontop",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:gaffer",
+            "target": "db:zipg",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:stellardb",
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:traverse",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:rocketgraph",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:gfql",
+            "target": "db:puppygraph",
+            "similarity": 0.3
+          },
+          {
+            "source": "db:gfql",
+            "target": "db:prometheux",
+            "similarity": 0.2
+          },
+          {
+            "source": "db:gfql",
+            "target": "db:rocketgraph",
+            "similarity": 0.2
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:google-cayley",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:dydra",
+            "target": "db:google-cayley",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:grafeo",
+            "similarity": 0.3846
+          },
+          {
+            "source": "db:grafeo",
+            "target": "db:millenniumdb",
+            "similarity": 0.3846
+          },
+          {
+            "source": "db:grafeo",
+            "target": "db:terminusdb",
+            "similarity": 0.3846
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:graph-engine",
+            "similarity": 0.4286
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:graph-engine",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:graph-engine",
+            "target": "db:graphbase",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:graphbase",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:bigquery-graph",
+            "target": "db:graphbase",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:graphflow",
+            "target": "db:pandadb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:graphflow",
+            "target": "db:youtrackdb",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:graphlite",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:graphqlite",
+            "target": "db:yugabytedb-mage",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:graphqlite",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:graphscope",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:graphscope",
+            "target": "db:tugraph",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:graphlite",
+            "target": "db:grust",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:grust",
+            "target": "db:omnigraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:gstore",
+            "target": "db:parliament",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:gstore",
+            "target": "db:qlever",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:gstore",
+            "target": "db:tentris",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:gun",
+            "target": "db:omnigraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:gun",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:graph-engine",
+            "target": "db:gun",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:halyard",
+            "target": "db:marmotta-kiwi",
+            "similarity": 1
+          },
+          {
+            "source": "db:halyard",
+            "target": "db:mulgara",
+            "similarity": 0.8571
+          },
+          {
+            "source": "db:g-tran",
+            "target": "db:helixdb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:helixdb",
+            "target": "db:minigraf",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:hgraphdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:hgraphdb",
+            "target": "db:hypergraphdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:huawei-ges",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:huawei-ges",
+            "target": "db:neptune",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:huawei-ges",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:hypergraphdb",
+            "target": "db:zipg",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:hypergraphdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:ibm-system-g",
+            "target": "db:objectivity-db",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:infinitegraph",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:infinitegraph",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:graphbase",
+            "target": "db:infinitegraph",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:janusgraph",
+            "target": "db:tinkergraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:katanagraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:katanagraph",
+            "target": "db:kuzu",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:kglite",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:kinetica",
+            "target": "db:marklogic",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:kinetica",
+            "target": "db:sap-hana",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:kinetica",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:kuzu",
+            "target": "db:turbolynx",
+            "similarity": 1
+          },
+          {
+            "source": "db:kuzu",
+            "target": "db:ladybugdb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:ladybugdb",
+            "target": "db:turbolynx",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:lance-graph",
+            "target": "db:pggraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:lance-graph",
+            "target": "db:yugabytedb-mage",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:lance-graph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:livegraph",
+            "target": "db:zipg",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:livegraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bangdb",
+            "target": "db:livegraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:marklogic",
+            "target": "db:sap-hana",
+            "similarity": 0.6
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "db:marklogic",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:marmotta-kiwi",
+            "target": "db:mulgara",
+            "similarity": 0.8571
+          },
+          {
+            "source": "db:faunadb",
+            "target": "db:memgql",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:memgql",
+            "target": "db:millenniumdb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:memgraph",
+            "target": "db:turingdb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:huawei-ges",
+            "target": "db:memgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:gstore",
+            "target": "db:millenniumdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:millenniumdb",
+            "target": "db:qlever",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:millenniumdb",
+            "target": "db:tentris",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:minigraf",
+            "target": "db:triblespace",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:minigraf",
+            "target": "db:zipg",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:minigraf",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:nebulagraph",
+            "target": "db:tugraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:janusgraph",
+            "target": "db:nebulagraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nebulagraph",
+            "target": "db:sparksee",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:janusgraph",
+            "target": "db:neo4j",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:neo4j",
+            "target": "db:ongdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:altair-graph-lakehouse",
+            "target": "db:neptune",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:neug",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:neug",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bitsy",
+            "target": "db:neug",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nodedb",
+            "target": "db:rocketgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nodedb",
+            "target": "db:omnigraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:nodedb",
+            "target": "db:ongdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:nornicdb",
+            "target": "db:rocketgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nornicdb",
+            "target": "db:omnigraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:nornicdb",
+            "target": "db:ongdb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:omnigraph",
+            "target": "db:stromadb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:kglite",
+            "target": "db:omnigraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:ongdb",
+            "target": "db:rocketgraph",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:graphflow",
+            "target": "db:ongdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:ontop",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:ontop",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:ontotext-graphdb",
+            "target": "db:stardog",
+            "similarity": 0.75
+          },
+          {
+            "source": "db:ontotext-graphdb",
+            "target": "db:rdfox",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:ontotext-graphdb",
+            "target": "db:oracle-graph",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:neptune",
+            "target": "db:oracle-graph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:marklogic",
+            "target": "db:oracle-graph",
+            "similarity": 0.4545
+          },
+          {
+            "source": "db:orientdb",
+            "target": "db:youtrackdb",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:oxigraph",
+            "target": "db:sparkledb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:4store",
+            "target": "db:oxigraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:oxigraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:oxirs",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:grust",
+            "target": "db:oxirs",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:pandadb",
+            "target": "db:quine",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:pandadb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:parliament",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:pggraph",
+            "target": "db:yugabytedb-mage",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:pggraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:postgresql-sql-pgq",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:postgresql-sql-pgq",
+            "target": "db:rocketgraph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:4store",
+            "target": "db:postgresql-sql-pgq",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:prometheux",
+            "target": "db:puppygraph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:prometheux",
+            "target": "db:relationalai",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:memgql",
+            "target": "db:prometheux",
+            "similarity": 0.25
+          },
+          {
+            "source": "db:huawei-ges",
+            "target": "db:puppygraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:graphscope",
+            "target": "db:puppygraph",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:puppygraph",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:qlever",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:halyard",
+            "target": "db:qlever",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:quine",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:graphflow",
+            "target": "db:quine",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:omnigraph",
+            "target": "db:raphtory",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:raphtory",
+            "target": "db:stromadb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nodedb",
+            "target": "db:raphtory",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:oxirs",
+            "target": "db:rdf-trine",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:rdf-trine",
+            "target": "db:sparkledb",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:eclipse-rdf4j",
+            "target": "db:rdflib",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:rdflib",
+            "target": "db:redland",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:rdflib",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "db:rdfox",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:recallgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:grust",
+            "target": "db:recallgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:pggraph",
+            "target": "db:recallgraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:redisgraph-falkordb",
+            "target": "db:sparksee",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-age",
+            "target": "db:redisgraph-falkordb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:redisgraph-falkordb",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:4store",
+            "target": "db:redland",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:apache-jena-fuseki",
+            "target": "db:redland",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:redstore",
+            "target": "db:sparkledb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:redstore",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:relationalai",
+            "target": "db:ultipa",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:relationalai",
+            "similarity": 0.3
+          },
+          {
+            "source": "db:rocketgraph",
+            "target": "db:stellardb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:omnigraph",
+            "target": "db:rushdb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:rushdb",
+            "target": "db:stromadb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:rushdb",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:bighorn",
+            "target": "db:ryugraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:kuzu",
+            "target": "db:ryugraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:ryugraph",
+            "target": "db:turbolynx",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:sap-hana",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:sones-graphdb",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:rocketgraph",
+            "target": "db:sones-graphdb",
+            "similarity": 0.375
+          },
+          {
+            "source": "db:aerospike",
+            "target": "db:sones-graphdb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:spanner-graph",
+            "similarity": 0.6667
+          },
+          {
+            "source": "db:sparkledb",
+            "target": "db:tentris",
+            "similarity": 0.8333
+          },
+          {
+            "source": "db:sparksee",
+            "target": "db:tigergraph",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:sparksee",
+            "target": "db:tugraph",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:sparksee",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:rdfox",
+            "target": "db:stardog",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:stellardb",
+            "target": "db:traverse",
+            "similarity": 0.625
+          },
+          {
+            "source": "db:apache-rya",
+            "target": "db:strabon",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:halyard",
+            "target": "db:strabon",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:marmotta-kiwi",
+            "target": "db:strabon",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:stromadb",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:data-graphs",
+            "target": "db:surrealdb",
+            "similarity": 0.3636
+          },
+          {
+            "source": "db:grafeo",
+            "target": "db:surrealdb",
+            "similarity": 0.3571
+          },
+          {
+            "source": "db:fluree",
+            "target": "db:surrealdb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:bytegraph",
+            "target": "db:tao",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:cray-graph-engine",
+            "target": "db:tao",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:ibm-system-g",
+            "target": "db:tao",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:google-cayley",
+            "target": "db:terminusdb",
+            "similarity": 0.3636
+          },
+          {
+            "source": "db:kinetica",
+            "target": "db:tigergraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:nebulagraph",
+            "target": "db:tigergraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:triblespace",
+            "target": "db:zipg",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:agdb",
+            "target": "db:triblespace",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:apache-hugegraph",
+            "target": "db:tugraph",
+            "similarity": 0.5556
+          },
+          {
+            "source": "db:ryugraph",
+            "target": "db:turingdb",
+            "similarity": 0.7143
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:turingdb",
+            "similarity": 0.5714
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:typedb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:helixdb",
+            "target": "db:typedb",
+            "similarity": 0.3333
+          },
+          {
+            "source": "db:relationalai",
+            "target": "db:typedb",
+            "similarity": 0.3
+          },
+          {
+            "source": "db:alibaba-gdb",
+            "target": "db:ultipa",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:fabric-graph",
+            "target": "db:ultipa",
+            "similarity": 0.4286
+          },
+          {
+            "source": "db:galaxybase",
+            "target": "db:ultipa",
+            "similarity": 0.4286
+          },
+          {
+            "source": "db:duckpgq",
+            "target": "db:velocitygraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:graphqlite",
+            "target": "db:velocitygraph",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:marklogic",
+            "target": "db:virtuoso",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:cosmos-db",
+            "target": "db:virtuoso",
+            "similarity": 0.4444
+          },
+          {
+            "source": "db:millenniumdb",
+            "target": "db:virtuoso",
+            "similarity": 0.4
+          },
+          {
+            "source": "db:atomic-server",
+            "target": "db:weaver",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:bangdb",
+            "target": "db:weaver",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:g-tran",
+            "target": "db:weaver",
+            "similarity": 0.5
+          },
+          {
+            "source": "db:janusgraph",
+            "target": "db:youtrackdb",
+            "similarity": 0.625
+          }
+        ]
+      }
+    }
+  ],
+  "config": {
+    "version": 1,
+    "layout": "force",
+    "bindings": [
+      {
+        "channel": "size",
+        "source": {
+          "kind": "algorithm",
+          "id": "degree"
+        },
+        "resultType": "num"
+      },
+      {
+        "channel": "color",
+        "source": {
+          "kind": "field",
+          "id": "type"
+        },
+        "resultType": "cat"
+      },
+      {
+        "channel": "edgeWidth",
+        "source": {
+          "kind": "field",
+          "id": "similarity",
+          "target": "edge"
+        },
+        "resultType": "num"
+      }
+    ]
+  }
+}

--- a/scripts/generate-graphs.mjs
+++ b/scripts/generate-graphs.mjs
@@ -1,0 +1,208 @@
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse } from "smol-toml";
+
+const SOURCE_DIR = "src/content/databases";
+const OUTPUT_DIR = "public/graphs";
+
+const files = (await readdir(SOURCE_DIR))
+  .filter((file) => file.endsWith(".toml"))
+  .sort();
+const databases = await Promise.all(
+  files.map(async (file) => {
+    const data = parse(await readFile(join(SOURCE_DIR, file), "utf8"));
+    return {
+      slug: String(data.slug),
+      name: String(data.name),
+      type: String(data.type),
+      kind: String(data.kind ?? "database"),
+      category: String(data.category),
+      status: String(data.status ?? "active"),
+      license: data.license ? String(data.license) : null,
+      implementationLanguage: data.implementation_language
+        ? String(data.implementation_language)
+        : null,
+      queryLanguages: Array.isArray(data.query_languages)
+        ? data.query_languages.map(String)
+        : [],
+    };
+  }),
+);
+
+function document(name, nodes, links, config) {
+  return {
+    info: { version: 1, name },
+    datasets: [
+      {
+        id: "main",
+        graph: {
+          directed: false,
+          multigraph: false,
+          graph: { name },
+          nodes,
+          links,
+        },
+      },
+    ],
+    config,
+  };
+}
+
+const sizeByDegree = {
+  channel: "size",
+  source: { kind: "algorithm", id: "degree" },
+  resultType: "num",
+};
+
+function bipartiteDocument() {
+  const languageNames = [
+    ...new Set(databases.flatMap((database) => database.queryLanguages)),
+  ].sort();
+  const nodes = [
+    ...databases.map((database) => ({
+      id: `db:${database.slug}`,
+      label: database.name,
+      kind: "Database",
+      type: database.type,
+      category: database.category,
+      status: database.status,
+    })),
+    ...languageNames.map((language) => ({
+      id: `language:${language}`,
+      label: language,
+      kind: "Query language",
+    })),
+  ];
+  const links = databases.flatMap((database) =>
+    database.queryLanguages.map((language) => ({
+      source: `db:${database.slug}`,
+      target: `language:${language}`,
+      relationship: "supports",
+    })),
+  );
+
+  return document("Databases × query languages", nodes, links, {
+    version: 1,
+    layout: "force",
+    bindings: [
+      sizeByDegree,
+      {
+        channel: "color",
+        source: { kind: "field", id: "kind" },
+        resultType: "cat",
+      },
+    ],
+  });
+}
+
+function featureTokens(database) {
+  const tokens = [
+    `type:${database.type}`,
+    `kind:${database.kind}`,
+    `category:${database.category}`,
+  ];
+  if (database.license) tokens.push(`license:${database.license}`);
+  if (database.implementationLanguage) {
+    tokens.push(`implementation:${database.implementationLanguage}`);
+  }
+  for (const language of database.queryLanguages) {
+    tokens.push(`query:${language}`);
+  }
+  return new Set(tokens.map((token) => token.toLocaleLowerCase()));
+}
+
+function jaccard(left, right) {
+  let intersection = 0;
+  for (const token of left) {
+    if (right.has(token)) intersection += 1;
+  }
+  return intersection / (left.size + right.size - intersection);
+}
+
+function similarityDocument() {
+  const tokens = new Map(
+    databases.map((database) => [database.slug, featureTokens(database)]),
+  );
+  const candidates = [];
+  for (let left = 0; left < databases.length; left += 1) {
+    for (let right = left + 1; right < databases.length; right += 1) {
+      const source = databases[left];
+      const target = databases[right];
+      candidates.push({
+        source: source.slug,
+        target: target.slug,
+        similarity: jaccard(tokens.get(source.slug), tokens.get(target.slug)),
+      });
+    }
+  }
+
+  const links = new Map();
+  for (const database of databases) {
+    const nearest = candidates
+      .filter(
+        (candidate) =>
+          candidate.source === database.slug ||
+          candidate.target === database.slug,
+      )
+      .sort(
+        (a, b) =>
+          b.similarity - a.similarity ||
+          a.source.localeCompare(b.source) ||
+          a.target.localeCompare(b.target),
+      )
+      .slice(0, 3);
+    for (const edge of nearest) {
+      const key = `${edge.source}\0${edge.target}`;
+      links.set(key, {
+        source: `db:${edge.source}`,
+        target: `db:${edge.target}`,
+        similarity: Number(edge.similarity.toFixed(4)),
+      });
+    }
+  }
+
+  const nodes = databases.map((database) => ({
+    id: `db:${database.slug}`,
+    label: database.name,
+    type: database.type,
+    kind: database.kind,
+    category: database.category,
+    status: database.status,
+    license: database.license,
+    implementationLanguage: database.implementationLanguage,
+    queryLanguages: database.queryLanguages.join(", "),
+  }));
+
+  return document("Database similarity", nodes, [...links.values()], {
+    version: 1,
+    layout: "force",
+    bindings: [
+      sizeByDegree,
+      {
+        channel: "color",
+        source: { kind: "field", id: "type" },
+        resultType: "cat",
+      },
+      {
+        channel: "edgeWidth",
+        source: { kind: "field", id: "similarity", target: "edge" },
+        resultType: "num",
+      },
+    ],
+  });
+}
+
+await mkdir(OUTPUT_DIR, { recursive: true });
+const outputs = [
+  ["databases-languages.gfd", bipartiteDocument()],
+  ["databases-similarity.gfd", similarityDocument()],
+];
+for (const [filename, graph] of outputs) {
+  await writeFile(
+    join(OUTPUT_DIR, filename),
+    `${JSON.stringify(graph, null, 2)}\n`,
+  );
+  console.log(
+    `${filename}: ${graph.datasets[0].graph.nodes.length} nodes, ${graph.datasets[0].graph.links.length} edges`,
+  );
+}

--- a/scripts/generate-graphs.mjs
+++ b/scripts/generate-graphs.mjs
@@ -63,6 +63,13 @@ const imageByUrl = {
   resultType: "cat",
 };
 
+const hullByType = {
+  channel: "hull",
+  source: { kind: "field", id: "type" },
+  resultType: "cat",
+  enabled: false,
+};
+
 function databaseNode(database) {
   return {
     id: `db:${database.slug}`,
@@ -103,6 +110,7 @@ function bipartiteDocument() {
     bindings: [
       sizeByDegree,
       imageByUrl,
+      hullByType,
       {
         channel: "color",
         source: { kind: "field", id: "kind" },
@@ -195,6 +203,7 @@ function similarityDocument() {
     bindings: [
       sizeByDegree,
       imageByUrl,
+      hullByType,
       {
         channel: "color",
         source: { kind: "field", id: "type" },

--- a/scripts/generate-graphs.mjs
+++ b/scripts/generate-graphs.mjs
@@ -4,6 +4,9 @@ import { parse } from "smol-toml";
 
 const SOURCE_DIR = "src/content/databases";
 const OUTPUT_DIR = "public/graphs";
+const SITE_ORIGIN = (
+  process.env.PUBLIC_SITE_ORIGIN ?? "https://gdb-engines.com"
+).replace(/\/+$/, "");
 
 const files = (await readdir(SOURCE_DIR))
   .filter((file) => file.endsWith(".toml"))
@@ -54,14 +57,27 @@ const sizeByDegree = {
   resultType: "num",
 };
 
+const imageByUrl = {
+  channel: "image",
+  source: { kind: "field", id: "image" },
+  resultType: "cat",
+};
+
+function databaseNode(database) {
+  return {
+    id: `db:${database.slug}`,
+    label: database.name,
+    image: `${SITE_ORIGIN}/logos/${encodeURIComponent(database.slug)}.png`,
+  };
+}
+
 function bipartiteDocument() {
   const languageNames = [
     ...new Set(databases.flatMap((database) => database.queryLanguages)),
   ].sort();
   const nodes = [
     ...databases.map((database) => ({
-      id: `db:${database.slug}`,
-      label: database.name,
+      ...databaseNode(database),
       kind: "Database",
       type: database.type,
       category: database.category,
@@ -86,6 +102,7 @@ function bipartiteDocument() {
     layout: "force",
     bindings: [
       sizeByDegree,
+      imageByUrl,
       {
         channel: "color",
         source: { kind: "field", id: "kind" },
@@ -162,8 +179,7 @@ function similarityDocument() {
   }
 
   const nodes = databases.map((database) => ({
-    id: `db:${database.slug}`,
-    label: database.name,
+    ...databaseNode(database),
     type: database.type,
     kind: database.kind,
     category: database.category,
@@ -178,6 +194,7 @@ function similarityDocument() {
     layout: "force",
     bindings: [
       sizeByDegree,
+      imageByUrl,
       {
         channel: "color",
         source: { kind: "field", id: "type" },

--- a/scripts/generate-graphs.mjs
+++ b/scripts/generate-graphs.mjs
@@ -63,13 +63,6 @@ const imageByUrl = {
   resultType: "cat",
 };
 
-const hullByType = {
-  channel: "hull",
-  source: { kind: "field", id: "type" },
-  resultType: "cat",
-  enabled: false,
-};
-
 function databaseNode(database) {
   return {
     id: `db:${database.slug}`,
@@ -110,7 +103,6 @@ function bipartiteDocument() {
     bindings: [
       sizeByDegree,
       imageByUrl,
-      hullByType,
       {
         channel: "color",
         source: { kind: "field", id: "kind" },
@@ -203,7 +195,6 @@ function similarityDocument() {
     bindings: [
       sizeByDegree,
       imageByUrl,
-      hullByType,
       {
         channel: "color",
         source: { kind: "field", id: "type" },

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -14,6 +14,7 @@ const databaseCount = comparisonControls ? await getDatabaseCount() : null;
 // (/rankings/cypher/ lights up "Rankings").
 const path = Astro.url.pathname;
 const onRankings = path.startsWith('/rankings');
+const onGraph = path.startsWith('/graph');
 const onCompare = path.startsWith('/compare');
 
 /**
@@ -39,6 +40,7 @@ const onCompare = path.startsWith('/compare');
       </svg>
       <span class="rankings-link__label">Rankings</span>
     </a>
+    <a href="/graph/" class:list={['rankings-link', onGraph && 'is-active']} aria-current={onGraph ? 'page' : undefined}>Graph</a>
     <a href="/compare/" class:list={['rankings-link', onCompare && 'is-active']} aria-current={onCompare ? 'page' : undefined} aria-label="Compare graph databases side by side">
       <svg class="rankings-link__icon" width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
         <path d="M239.43,133l-32-80h0a8,8,0,0,0-9.16-4.84L136,62V40a8,8,0,0,0-16,0V65.58L54.26,80.19A8,8,0,0,0,48.57,85h0v.06L16.57,165a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32a7.92,7.92,0,0,0-.57-3L66.92,93.77,120,82V208H104a8,8,0,0,0,0,16h48a8,8,0,0,0,0-16H136V78.42L187,67.1,160.57,133a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32A7.92,7.92,0,0,0,239.43,133ZM56,184c-7.53,0-22.76-3.61-23.93-14.64L56,109.54l23.93,59.82C78.76,180.39,63.53,184,56,184Zm144-32c-7.53,0-22.76-3.61-23.93-14.64L200,77.54l23.93,59.82C222.76,148.39,207.53,152,200,152Z"/>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -51,7 +51,7 @@ const onCompare = path.startsWith('/compare');
       <span class="rankings-link__label">Graph</span>
     </a>
     <a href="/compare/" class:list={['rankings-link', onCompare && 'is-active']} aria-current={onCompare ? 'page' : undefined} aria-label="Compare graph databases side by side">
-      <svg class="rankings-link__icon" width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
+      <svg class="rankings-link__icon" width="16" height="16" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
         <path d="M239.43,133l-32-80h0a8,8,0,0,0-9.16-4.84L136,62V40a8,8,0,0,0-16,0V65.58L54.26,80.19A8,8,0,0,0,48.57,85h0v.06L16.57,165a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32a7.92,7.92,0,0,0-.57-3L66.92,93.77,120,82V208H104a8,8,0,0,0,0,16h48a8,8,0,0,0,0-16H136V78.42L187,67.1,160.57,133a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32A7.92,7.92,0,0,0,239.43,133ZM56,184c-7.53,0-22.76-3.61-23.93-14.64L56,109.54l23.93,59.82C78.76,180.39,63.53,184,56,184Zm144-32c-7.53,0-22.76-3.61-23.93-14.64L200,77.54l23.93,59.82C222.76,148.39,207.53,152,200,152Z"/>
       </svg>
       <span class="rankings-link__label">Compare</span>

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -40,7 +40,16 @@ const onCompare = path.startsWith('/compare');
       </svg>
       <span class="rankings-link__label">Rankings</span>
     </a>
-    <a href="/graph/" class:list={['rankings-link', onGraph && 'is-active']} aria-current={onGraph ? 'page' : undefined}>Graph</a>
+    <a href="/graph/" class:list={['rankings-link', 'graph-link', onGraph && 'is-active']} aria-current={onGraph ? 'page' : undefined}>
+      <svg class="rankings-link__icon graph-link__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M4 4.5 8 7m0 0 4-3M8 7l1.5 4.5"/>
+        <circle cx="3" cy="3.75" r="1.75"/>
+        <circle cx="13" cy="3.25" r="1.75"/>
+        <circle cx="10" cy="13" r="1.75"/>
+        <circle cx="8" cy="7" r="1.5"/>
+      </svg>
+      <span class="rankings-link__label">Graph</span>
+    </a>
     <a href="/compare/" class:list={['rankings-link', onCompare && 'is-active']} aria-current={onCompare ? 'page' : undefined} aria-label="Compare graph databases side by side">
       <svg class="rankings-link__icon" width="14" height="14" viewBox="0 0 256 256" fill="currentColor" aria-hidden="true">
         <path d="M239.43,133l-32-80h0a8,8,0,0,0-9.16-4.84L136,62V40a8,8,0,0,0-16,0V65.58L54.26,80.19A8,8,0,0,0,48.57,85h0v.06L16.57,165a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32a7.92,7.92,0,0,0-.57-3L66.92,93.77,120,82V208H104a8,8,0,0,0,0,16h48a8,8,0,0,0,0-16H136V78.42L187,67.1,160.57,133a7.92,7.92,0,0,0-.57,3c0,23.31,24.54,32,40,32s40-8.69,40-32A7.92,7.92,0,0,0,239.43,133ZM56,184c-7.53,0-22.76-3.61-23.93-14.64L56,109.54l23.93,59.82C78.76,180.39,63.53,184,56,184Zm144-32c-7.53,0-22.76-3.61-23.93-14.64L200,77.54l23.93,59.82C222.76,148.39,207.53,152,200,152Z"/>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -15,7 +15,6 @@ import { getCollection } from 'astro:content';
 import { buildFaviconMap } from '../../lib/favicon-map';
 import { loadRankings } from '../../lib/rankings';
 import { pregeneratedPairs, resolveRoundup, buildOverallRankMap, pairSlug } from '../../lib/comparisons';
-import { featureCount } from '../../data/feature-metadata';
 import { canonicalQueryLanguage } from '../../lib/ranking-boards';
 
 const ranking = await loadRankings();
@@ -99,8 +98,8 @@ const breadcrumbJsonLd = JSON.stringify({
     <h1>Compare graph databases side by side</h1>
     <p class="lead">
       {pregenerated.size} pre-built comparisons across {databases.length} catalogue engines. Each one
-      shows rank, license, query languages, implementation language and the {featureCount} survey feature
-      scores in one table.
+      shows rank, license, query languages, implementation language and academic research details where
+      available.
     </p>
 
     <section class="group build">
@@ -139,8 +138,8 @@ const breadcrumbJsonLd = JSON.stringify({
 </Layout>
 
 <style>
-  .compare-hub { padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem; max-width: var(--content-max-width); margin: 0 auto; }
-  h1 { font-size: 1.5rem; margin: 0 0 0.5rem; line-height: 1.2; color: var(--color-text); }
+  .compare-hub { max-width: var(--content-max-width); margin: 0 auto; padding: calc(var(--header-height) + 1.5rem) 1.25rem 3rem; }
+  h1 { font-size: 1.5rem; margin: 0 0 0.5rem; color: var(--color-text); }
   h2 { font-size: 0.8rem; font-family: 'Familjen Grotesk', sans-serif; font-weight: 600; text-transform: uppercase; letter-spacing: -0.5px; color: var(--color-text-secondary); margin: 2rem 0 0.5rem; }
   .lead { color: var(--color-text); line-height: 1.55; max-width: 90ch; margin: 0.75rem 0 1.25rem; }
   .pair-list { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr)); gap: 0.35rem 1rem; }

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -1,0 +1,315 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SiteHeader from '../components/SiteHeader.astro';
+import { getDatabaseCount } from '../lib/database-count';
+import '../styles/global.css';
+
+const databaseCount = await getDatabaseCount();
+const garphieldOrigin =
+  import.meta.env.PUBLIC_GARPHIELD_ORIGIN ?? 'https://garphield.com';
+---
+<Layout
+  title="Explore the graph database landscape — GDB-Engines"
+  description={`Explore relationships among ${databaseCount} graph databases by query-language support and catalog similarity.`}
+  canonical="https://gdb-engines.com/graph/"
+>
+  <SiteHeader />
+
+  <main class="graph-page" data-garphield-origin={garphieldOrigin}>
+    <section class="graph-intro">
+      <div>
+        <h1>Graph Database Map</h1>
+        <p id="model-description">
+          Connect databases to the query languages they support. Larger nodes
+          participate in more relationships.
+        </p>
+      </div>
+      <div class="model-switcher" role="group" aria-label="Graph model">
+        <button
+          type="button"
+          class="model-button active"
+          data-document="/graphs/databases-languages.gfd"
+          data-description="Connect databases to the query languages they support. Larger nodes participate in more relationships."
+          aria-pressed="true"
+        >
+          Query languages
+        </button>
+        <button
+          type="button"
+          class="model-button"
+          data-document="/graphs/databases-similarity.gfd"
+          data-description="Connect each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
+          aria-pressed="false"
+        >
+          Similarity
+        </button>
+      </div>
+    </section>
+
+    <section class="graph-stage" aria-label="Interactive graph visualization">
+      <div class="graph-status-row">
+        <p id="graph-status" role="status">Starting visualization…</p>
+        <p id="graph-selection">Click a node to inspect it.</p>
+      </div>
+      <iframe
+        id="garphield-frame"
+        title="Graph database landscape visualization"
+        loading="eager"
+      ></iframe>
+    </section>
+
+    <noscript>
+      <p class="graph-fallback">
+        JavaScript is required for the interactive view. The underlying
+        <a href="/graphs/databases-languages.gfd">query-language graph</a> and
+        <a href="/graphs/databases-similarity.gfd">similarity graph</a> are
+        available as structured Garphield documents.
+      </p>
+    </noscript>
+  </main>
+
+  <script>
+    import { createGarphield } from 'garphield';
+
+    const page = document.querySelector('.graph-page');
+    const frame = document.querySelector('#garphield-frame');
+    const status = document.querySelector('#graph-status');
+    const selection = document.querySelector('#graph-selection');
+    const description = document.querySelector('#model-description');
+    const buttons = [...document.querySelectorAll('.model-button')];
+
+    if (
+      page instanceof HTMLElement &&
+      frame instanceof HTMLIFrameElement &&
+      status instanceof HTMLElement &&
+      selection instanceof HTMLElement &&
+      description instanceof HTMLElement
+    ) {
+      const origin = page.dataset.garphieldOrigin ?? 'https://garphield.com';
+      const driver = createGarphield(frame, {
+        embedUrl: new URL('/embed', origin),
+        timeoutMs: 30_000,
+      });
+      let labels = new Map();
+      let loadVersion = 0;
+
+      driver.on('nodeClick', (payload) => {
+        selection.textContent = `Selected: ${labels.get(payload.nodeId) ?? payload.nodeId}`;
+      });
+      driver.on('error', (payload) => {
+        status.textContent = `Visualization error: ${payload.message}`;
+      });
+
+      const ready = driver.ready();
+      const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+
+      function effectiveTheme(): 'light' | 'dark' {
+        const explicit = document.documentElement.dataset.theme;
+        if (explicit === 'light' || explicit === 'dark') return explicit;
+        return colorScheme.matches ? 'dark' : 'light';
+      }
+
+      async function syncTheme() {
+        await ready;
+        await driver.setTheme({ colorScheme: effectiveTheme() });
+      }
+
+      function reportThemeError(error: unknown) {
+        status.textContent = `Could not match visualization theme: ${String(error)}`;
+      }
+
+      const themeObserver = new MutationObserver(() => {
+        void syncTheme().catch(reportThemeError);
+      });
+      themeObserver.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ['data-theme'],
+      });
+      const systemThemeListener = () => {
+        if (!document.documentElement.dataset.theme) {
+          void syncTheme().catch(reportThemeError);
+        }
+      };
+      colorScheme.addEventListener('change', systemThemeListener);
+
+      async function loadDocument(button) {
+        const version = ++loadVersion;
+        for (const candidate of buttons) {
+          const active = candidate === button;
+          candidate.classList.toggle('active', active);
+          candidate.setAttribute('aria-pressed', String(active));
+        }
+        description.textContent = button.dataset.description ?? '';
+        selection.textContent = 'Click a node to inspect it.';
+        status.textContent = `Loading ${button.textContent.trim()}…`;
+
+        try {
+          const response = await fetch(button.dataset.document);
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          const document = await response.json();
+          await syncTheme();
+          await driver.setDocument(document);
+          if (version !== loadVersion) return;
+          const graph = document.datasets[0].graph;
+          labels = new Map(
+            graph.nodes.map((node) => [
+              String(node.id),
+              String(node.label ?? node.id),
+            ]),
+          );
+          status.textContent = `${button.textContent.trim()} · ${graph.nodes.length} nodes · ${graph.links.length} relationships`;
+        } catch (error) {
+          if (version !== loadVersion) return;
+          status.textContent = `Could not load visualization: ${String(error)}`;
+        }
+      }
+
+      for (const button of buttons) {
+        button.addEventListener('click', () => loadDocument(button));
+      }
+      loadDocument(buttons[0]);
+      window.addEventListener(
+        'pagehide',
+        () => {
+          themeObserver.disconnect();
+          colorScheme.removeEventListener('change', systemThemeListener);
+          driver.destroy();
+        },
+        { once: true },
+      );
+    }
+  </script>
+
+  <style>
+    .graph-page {
+      min-height: 100vh;
+      padding: calc(var(--header-height) + 1rem) 1rem 1rem;
+      display: grid;
+      grid-template-rows: auto minmax(34rem, 1fr);
+      gap: 1rem;
+      background:
+        radial-gradient(circle at 15% 10%, color-mix(in srgb, var(--color-brand) 14%, transparent), transparent 28rem),
+        var(--color-background);
+    }
+
+    .graph-intro {
+      width: min(100%, 92rem);
+      margin: 0 auto;
+      display: flex;
+      align-items: end;
+      justify-content: space-between;
+      gap: 1.5rem;
+    }
+
+    .graph-intro > div:first-child {
+      min-width: 0;
+    }
+
+    .graph-intro h1 {
+      font-family: var(--font-heading);
+      font-size: clamp(1.75rem, 4vw, 3rem);
+      line-height: 1;
+      letter-spacing: -0.03em;
+      margin: 0 0 0.5rem;
+    }
+
+    #model-description {
+      max-width: 54rem;
+      color: var(--color-text-secondary);
+    }
+
+    .model-switcher {
+      display: flex;
+      padding: 0.25rem;
+      border: 1px solid var(--color-border);
+      border-radius: 0.5rem;
+      background: var(--color-surface);
+      flex: 0 0 auto;
+    }
+
+    .model-button {
+      border: 0;
+      border-radius: 0.35rem;
+      padding: 0.55rem 0.8rem;
+      background: transparent;
+      color: var(--color-text-secondary);
+      cursor: pointer;
+      font-size: 0.8125rem;
+    }
+
+    .model-button.active {
+      background: var(--color-background);
+      color: var(--color-text);
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+    }
+
+    .graph-stage {
+      width: min(100%, 92rem);
+      min-height: 34rem;
+      margin: 0 auto;
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+      border: 1px solid var(--color-border);
+      border-radius: 0.75rem;
+      background: var(--color-background);
+      box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.08);
+    }
+
+    .graph-status-row {
+      min-height: 2.75rem;
+      padding: 0.6rem 0.85rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+      border-bottom: 1px solid var(--color-border);
+      color: var(--color-text-secondary);
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+    }
+
+    #garphield-frame {
+      width: 100%;
+      height: 100%;
+      min-height: 31rem;
+      border: 0;
+      background: var(--color-background);
+    }
+
+    .graph-fallback {
+      width: min(100%, 92rem);
+      margin: 0 auto;
+      padding: 1rem;
+      border: 1px solid var(--color-border);
+    }
+
+    @media (max-width: 68rem) {
+      .graph-page {
+        grid-template-rows: auto minmax(34rem, 70vh);
+      }
+
+      .graph-intro {
+        align-items: stretch;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .model-switcher {
+        align-self: flex-start;
+      }
+    }
+
+    @media (max-width: 48rem) {
+      .graph-page {
+        padding-inline: 0.5rem;
+      }
+
+      .graph-status-row {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+    }
+  </style>
+</Layout>

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -49,18 +49,24 @@ const garphieldOrigin =
               Similarity
             </button>
           </div>
-          <label id="similarity-control" hidden>
-            <span>Min similarity</span>
-            <input
-              id="similarity-threshold"
-              type="range"
-              min="0.2"
-              max="0.8"
-              value="0.2"
-              step="0.05"
-            />
-            <output id="similarity-value" for="similarity-threshold">≥ 20%</output>
-          </label>
+          <div id="similarity-control" hidden>
+            <label class="similarity-threshold-control">
+              <span>Min similarity</span>
+              <input
+                id="similarity-threshold"
+                type="range"
+                min="0.2"
+                max="0.8"
+                value="0.2"
+                step="0.05"
+              />
+              <output id="similarity-value" for="similarity-threshold">≥ 20%</output>
+            </label>
+            <label class="hull-control">
+              <input id="similarity-hulls" type="checkbox" />
+              <span>Type hulls</span>
+            </label>
+          </div>
         </div>
         <div class="graph-status-right">
           <p id="graph-selection" aria-live="polite" hidden></p>
@@ -96,6 +102,7 @@ const garphieldOrigin =
     const similarityControl = document.querySelector('#similarity-control');
     const similarityThreshold = document.querySelector('#similarity-threshold');
     const similarityValue = document.querySelector('#similarity-value');
+    const similarityHulls = document.querySelector('#similarity-hulls');
     const buttons = [...document.querySelectorAll('.model-button')];
 
     if (
@@ -105,9 +112,10 @@ const garphieldOrigin =
       status instanceof HTMLElement &&
       selection instanceof HTMLElement &&
       description instanceof HTMLElement &&
-      similarityControl instanceof HTMLLabelElement &&
+      similarityControl instanceof HTMLElement &&
       similarityThreshold instanceof HTMLInputElement &&
-      similarityValue instanceof HTMLOutputElement
+      similarityValue instanceof HTMLOutputElement &&
+      similarityHulls instanceof HTMLInputElement
     ) {
       const origin = page.dataset.garphieldOrigin ?? 'https://garphield.com';
       const driver = createGarphield(frame, {
@@ -119,6 +127,8 @@ const garphieldOrigin =
       let activeButton = null;
       let hasRendered = false;
       let loadVersion = 0;
+      let similarityFilterFrame = 0;
+      let similarityFilterVersion = 0;
 
       function clearSelection() {
         selection.replaceChildren();
@@ -199,18 +209,51 @@ const garphieldOrigin =
         similarityValue.value = `≥ ${Math.round(Number(similarityThreshold.value) * 100)}%`;
       }
 
-      function documentForCurrentView(source) {
-        const document = structuredClone(source);
+      function updateGraphStatus(graph, visibleLinks = graph.links.length) {
+        const databaseCount = graph.nodes.filter((node) =>
+          String(node.id).startsWith('db:'),
+        ).length;
         if (activeButton?.dataset.document?.includes('similarity')) {
-          const threshold = Number(similarityThreshold.value);
-          const graph = document.datasets[0].graph;
-          graph.links = graph.links.filter(
-            (link) =>
-              typeof link.similarity === 'number' &&
-              link.similarity >= threshold,
-          );
+          status.textContent = `${databaseCount} databases · ${visibleLinks} similar database pairs`;
+          return;
         }
-        return document;
+        const queryLanguageCount = graph.nodes.length - databaseCount;
+        status.textContent = `${databaseCount} databases · ${queryLanguageCount} query languages · ${visibleLinks} supported database–language pairings`;
+      }
+
+      async function applySimilarityFilter() {
+        if (
+          !activeDocument ||
+          !activeButton?.dataset.document?.includes('similarity')
+        ) {
+          return;
+        }
+        const version = ++similarityFilterVersion;
+        const threshold = Number(similarityThreshold.value);
+        const graph = activeDocument.datasets[0].graph;
+        const visibleLinks = graph.links.filter(
+          (link) =>
+            typeof link.similarity === 'number' &&
+            link.similarity >= threshold,
+        ).length;
+        updateGraphStatus(graph, visibleLinks);
+        try {
+          await driver.call('setEdgeFilter', {
+            field: 'similarity',
+            min: threshold,
+          });
+        } catch (error) {
+          if (version !== similarityFilterVersion) return;
+          status.textContent = `Could not filter similarity relationships: ${String(error)}`;
+        }
+      }
+
+      function scheduleSimilarityFilter() {
+        if (similarityFilterFrame !== 0) return;
+        similarityFilterFrame = requestAnimationFrame(() => {
+          similarityFilterFrame = 0;
+          void applySimilarityFilter();
+        });
       }
 
       async function renderDocument(source, version) {
@@ -220,7 +263,7 @@ const garphieldOrigin =
           await new Promise((resolve) => window.setTimeout(resolve, 180));
         }
 
-        const document = documentForCurrentView(source);
+        const document = structuredClone(source);
         await syncTheme();
         await driver.setDocument(document);
         if (version !== loadVersion) return;
@@ -229,15 +272,7 @@ const garphieldOrigin =
         nodes = new Map(
           graph.nodes.map((node) => [String(node.id), node]),
         );
-        const databaseCount = graph.nodes.filter((node) =>
-          String(node.id).startsWith('db:'),
-        ).length;
-        if (activeButton?.dataset.document?.includes('similarity')) {
-          status.textContent = `${databaseCount} databases · ${graph.links.length} similar database pairs`;
-        } else {
-          const queryLanguageCount = graph.nodes.length - databaseCount;
-          status.textContent = `${databaseCount} databases · ${queryLanguageCount} query languages · ${graph.links.length} supported database–language pairings`;
-        }
+        updateGraphStatus(graph);
         await new Promise((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(resolve)),
         );
@@ -257,6 +292,7 @@ const garphieldOrigin =
         description.textContent = button.dataset.description ?? '';
         similarityControl.hidden =
           !button.dataset.document?.includes('similarity');
+        similarityHulls.checked = false;
         clearSelection();
         status.textContent = 'Loading…';
 
@@ -279,6 +315,7 @@ const garphieldOrigin =
           if (version !== loadVersion) return;
           activeDocument = document;
           await renderDocument(document, version);
+          await applySimilarityFilter();
         } catch (error) {
           if (version !== loadVersion) return;
           graphStage.classList.remove('switching');
@@ -287,22 +324,19 @@ const garphieldOrigin =
       }
 
       updateSimilarityLabel();
-      similarityThreshold.addEventListener('input', updateSimilarityLabel);
-      similarityThreshold.addEventListener('change', () => {
-        if (
-          !activeDocument ||
-          !activeButton?.dataset.document?.includes('similarity')
-        ) {
-          return;
-        }
-        const version = ++loadVersion;
-        clearSelection();
-        status.textContent = 'Updating…';
-        void renderDocument(activeDocument, version).catch((error) => {
-          if (version !== loadVersion) return;
-          graphStage.classList.remove('switching');
-          status.textContent = `Could not update visualization: ${String(error)}`;
-        });
+      similarityThreshold.addEventListener('input', () => {
+        updateSimilarityLabel();
+        scheduleSimilarityFilter();
+      });
+      similarityHulls.addEventListener('change', () => {
+        void driver
+          .call('setBindingEnabled', {
+            channel: 'hull',
+            enabled: similarityHulls.checked,
+          })
+          .catch((error) => {
+            status.textContent = `Could not toggle type hulls: ${String(error)}`;
+          });
       });
 
       for (const button of buttons) {
@@ -314,6 +348,9 @@ const garphieldOrigin =
         () => {
           themeObserver.disconnect();
           colorScheme.removeEventListener('change', systemThemeListener);
+          if (similarityFilterFrame !== 0) {
+            cancelAnimationFrame(similarityFilterFrame);
+          }
           driver.destroy();
         },
         { once: true },
@@ -428,12 +465,27 @@ const garphieldOrigin =
     #similarity-control {
       display: flex;
       align-items: center;
-      gap: 0.4rem;
+      gap: 0.8rem;
       white-space: nowrap;
     }
 
     #similarity-control[hidden] {
       display: none;
+    }
+
+    .similarity-threshold-control,
+    .hull-control {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+
+    .hull-control {
+      cursor: pointer;
+    }
+
+    .hull-control input {
+      accent-color: var(--color-brand);
     }
 
     #similarity-threshold {
@@ -514,8 +566,15 @@ const garphieldOrigin =
       }
 
       .graph-status-left {
+        width: 100%;
         flex-wrap: wrap;
         gap: 0.4rem 0.65rem;
+      }
+
+      #similarity-control {
+        width: 100%;
+        justify-content: space-between;
+        gap: 0.5rem;
       }
 
       .graph-status-right {
@@ -527,7 +586,11 @@ const garphieldOrigin =
       }
 
       #similarity-threshold {
-        width: 6rem;
+        width: 5.5rem;
+      }
+
+      #similarity-value {
+        min-width: 2.75rem;
       }
     }
 

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -62,10 +62,6 @@ const garphieldOrigin =
               />
               <output id="similarity-value" for="similarity-threshold">≥ 20%</output>
             </label>
-            <label class="hull-control">
-              <input id="similarity-hulls" type="checkbox" />
-              <span>Type hulls</span>
-            </label>
           </div>
         </div>
         <div class="graph-status-right">
@@ -102,7 +98,6 @@ const garphieldOrigin =
     const similarityControl = document.querySelector('#similarity-control');
     const similarityThreshold = document.querySelector('#similarity-threshold');
     const similarityValue = document.querySelector('#similarity-value');
-    const similarityHulls = document.querySelector('#similarity-hulls');
     const buttons = [...document.querySelectorAll('.model-button')];
 
     if (
@@ -114,8 +109,7 @@ const garphieldOrigin =
       description instanceof HTMLElement &&
       similarityControl instanceof HTMLElement &&
       similarityThreshold instanceof HTMLInputElement &&
-      similarityValue instanceof HTMLOutputElement &&
-      similarityHulls instanceof HTMLInputElement
+      similarityValue instanceof HTMLOutputElement
     ) {
       const origin = page.dataset.garphieldOrigin ?? 'https://garphield.com';
       const driver = createGarphield(frame, {
@@ -330,7 +324,6 @@ const garphieldOrigin =
         description.textContent = button.dataset.description ?? '';
         similarityControl.hidden =
           !button.dataset.document?.includes('similarity');
-        similarityHulls.checked = false;
         clearSelection();
         status.textContent = 'Loading…';
 
@@ -369,17 +362,6 @@ const garphieldOrigin =
         updateSimilarityLabel();
         scheduleSimilarityFilter();
       });
-      similarityHulls.addEventListener('change', () => {
-        void driver
-          .call('setBindingEnabled', {
-            channel: 'hull',
-            enabled: similarityHulls.checked,
-          })
-          .catch((error) => {
-            status.textContent = `Could not toggle type hulls: ${String(error)}`;
-          });
-      });
-
       for (const button of buttons) {
         button.addEventListener('click', () => loadDocument(button));
       }
@@ -511,19 +493,10 @@ const garphieldOrigin =
       display: none;
     }
 
-    .similarity-threshold-control,
-    .hull-control {
+    .similarity-threshold-control {
       display: flex;
       align-items: center;
       gap: 0.4rem;
-    }
-
-    .hull-control {
-      cursor: pointer;
-    }
-
-    .hull-control input {
-      accent-color: var(--color-brand);
     }
 
     #similarity-threshold {

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -129,6 +129,44 @@ const garphieldOrigin =
       let loadVersion = 0;
       let similarityFilterFrame = 0;
       let similarityFilterVersion = 0;
+      const imageLoads = new Map<string, Promise<void>>();
+
+      function preloadImage(url: string): Promise<void> {
+        const existing = imageLoads.get(url);
+        if (existing) return existing;
+
+        const pending = new Promise<void>((resolve) => {
+          const image = new Image();
+          let settled = false;
+          const finish = () => {
+            if (settled) return;
+            settled = true;
+            window.clearTimeout(timeout);
+            resolve();
+          };
+          const timeout = window.setTimeout(finish, 8_000);
+          image.crossOrigin = 'anonymous';
+          image.decoding = 'async';
+          image.onerror = finish;
+          image.onload = () => {
+            void image.decode().catch(() => undefined).then(finish);
+          };
+          image.src = url;
+        });
+        imageLoads.set(url, pending);
+        return pending;
+      }
+
+      async function preloadNodeImages(document) {
+        const urls = [
+          ...new Set(
+            document.datasets[0].graph.nodes
+              .map((node) => node.image)
+              .filter((image): image is string => typeof image === 'string'),
+          ),
+        ];
+        await Promise.all(urls.map(preloadImage));
+      }
 
       function clearSelection() {
         selection.replaceChildren();
@@ -314,6 +352,9 @@ const garphieldOrigin =
           }
           if (version !== loadVersion) return;
           activeDocument = document;
+          status.textContent = 'Loading database icons…';
+          await preloadNodeImages(document);
+          if (version !== loadVersion) return;
           await renderDocument(document, version);
           await applySimilarityFilter();
         } catch (error) {
@@ -365,9 +406,6 @@ const garphieldOrigin =
       display: grid;
       grid-template-rows: auto minmax(34rem, 1fr);
       gap: 1rem;
-      background:
-        radial-gradient(circle at 15% 10%, color-mix(in srgb, var(--color-brand) 14%, transparent), transparent 28rem),
-        var(--color-background);
     }
 
     .graph-intro {

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -49,7 +49,6 @@ const garphieldOrigin =
               Similarity
             </button>
           </div>
-          <p id="graph-status" role="status">Starting visualization…</p>
           <label id="similarity-control" hidden>
             <span>Min similarity</span>
             <input
@@ -63,7 +62,10 @@ const garphieldOrigin =
             <output id="similarity-value" for="similarity-threshold">≥ 20%</output>
           </label>
         </div>
-        <p id="graph-selection" aria-live="polite" hidden></p>
+        <div class="graph-status-right">
+          <p id="graph-selection" aria-live="polite" hidden></p>
+          <p id="graph-status" role="status">Starting visualization…</p>
+        </div>
       </div>
       <iframe
         id="garphield-frame"
@@ -227,7 +229,15 @@ const garphieldOrigin =
         nodes = new Map(
           graph.nodes.map((node) => [String(node.id), node]),
         );
-        status.textContent = `${graph.nodes.length} nodes · ${graph.links.length} relationships`;
+        const databaseCount = graph.nodes.filter((node) =>
+          String(node.id).startsWith('db:'),
+        ).length;
+        if (activeButton?.dataset.document?.includes('similarity')) {
+          status.textContent = `${databaseCount} databases · ${graph.links.length} similar database pairs`;
+        } else {
+          const queryLanguageCount = graph.nodes.length - databaseCount;
+          status.textContent = `${databaseCount} databases · ${queryLanguageCount} query languages · ${graph.links.length} supported database–language pairings`;
+        }
         await new Promise((resolve) =>
           requestAnimationFrame(() => requestAnimationFrame(resolve)),
         );
@@ -406,6 +416,15 @@ const garphieldOrigin =
       gap: 0.75rem;
     }
 
+    .graph-status-right {
+      min-width: 0;
+      margin-left: auto;
+      display: flex;
+      align-items: center;
+      justify-content: flex-end;
+      gap: 1rem;
+    }
+
     #similarity-control {
       display: flex;
       align-items: center;
@@ -497,6 +516,14 @@ const garphieldOrigin =
       .graph-status-left {
         flex-wrap: wrap;
         gap: 0.4rem 0.65rem;
+      }
+
+      .graph-status-right {
+        width: 100%;
+        margin-left: 0;
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.3rem;
       }
 
       #similarity-threshold {

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -147,6 +147,18 @@ const garphieldOrigin =
           const response = await fetch(button.dataset.document);
           if (!response.ok) throw new Error(`HTTP ${response.status}`);
           const document = await response.json();
+          // Generated documents keep production-absolute asset URLs so they
+          // remain portable. In dev, point those same assets at this local GDB
+          // server; Garphield still receives a valid absolute URL.
+          if (import.meta.env.DEV) {
+            for (const node of document.datasets[0].graph.nodes) {
+              if (typeof node.image !== 'string') continue;
+              const image = new URL(node.image);
+              if (image.origin === 'https://gdb-engines.com') {
+                node.image = new URL(image.pathname, window.location.origin).href;
+              }
+            }
+          }
           await syncTheme();
           await driver.setDocument(document);
           if (version !== loadVersion) return;
@@ -285,13 +297,10 @@ const garphieldOrigin =
     }
 
     @media (max-width: 68rem) {
-      .graph-page {
-        grid-template-rows: auto minmax(34rem, 70vh);
-      }
-
       .graph-intro {
         align-items: stretch;
         flex-direction: column;
+        justify-content: flex-start;
         gap: 0.75rem;
       }
 

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -345,7 +345,6 @@ const garphieldOrigin =
           }
           if (version !== loadVersion) return;
           activeDocument = document;
-          status.textContent = 'Loading database icons…';
           await preloadNodeImages(document);
           if (version !== loadVersion) return;
           await renderDocument(document, version);

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -20,8 +20,7 @@ const garphieldOrigin =
       <div>
         <h1>Graph Database Map</h1>
         <p id="model-description">
-          Connect databases to the query languages they support. Larger nodes
-          participate in more relationships.
+          Databases linked via query languages supported.
         </p>
       </div>
     </section>
@@ -34,7 +33,7 @@ const garphieldOrigin =
               type="button"
               class="model-button active"
               data-document="/graphs/databases-languages.gfd"
-              data-description="Connect databases to the query languages they support. Larger nodes participate in more relationships."
+              data-description="Databases linked via query languages supported."
               aria-pressed="true"
             >
               Query languages
@@ -43,7 +42,7 @@ const garphieldOrigin =
               type="button"
               class="model-button"
               data-document="/graphs/databases-similarity.gfd"
-              data-description="Connect each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
+              data-description="Link each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
               aria-pressed="false"
             >
               Similarity
@@ -383,15 +382,17 @@ const garphieldOrigin =
   <style>
     .graph-page {
       min-height: 100vh;
-      padding: calc(var(--header-height) + 1rem) 1rem 1rem;
+      padding: calc(var(--header-height) + 1.5rem) 0 1.25rem;
       display: grid;
       grid-template-rows: auto minmax(34rem, 1fr);
-      gap: 1rem;
+      gap: 0;
     }
 
     .graph-intro {
-      width: min(100%, 92rem);
+      width: 100%;
+      max-width: var(--content-max-width);
       margin: 0 auto;
+      padding-inline: 1.25rem;
     }
 
     .graph-intro > div {
@@ -399,19 +400,18 @@ const garphieldOrigin =
     }
 
     .graph-intro h1 {
-      font-family: var(--font-heading);
-      font-size: clamp(1.75rem, 4vw, 3rem);
-      line-height: 1;
-      letter-spacing: -0.03em;
+      font-size: 1.5rem;
+      color: var(--color-text);
       margin: 0 0 0.5rem;
     }
 
     #model-description {
-      height: 3rem;
-      margin: 0;
+      height: 1.55em;
+      margin: 0.75rem 0 1.25rem;
       overflow: hidden;
-      max-width: 54rem;
-      color: var(--color-text-secondary);
+      max-width: 90ch;
+      color: var(--color-text);
+      line-height: 1.55;
     }
 
     .model-switcher {
@@ -440,7 +440,7 @@ const garphieldOrigin =
     }
 
     .graph-stage {
-      width: min(100%, 92rem);
+      width: min(calc(100% - 2.5rem), 92rem);
       min-height: 34rem;
       margin: 0 auto;
       display: grid;
@@ -552,7 +552,7 @@ const garphieldOrigin =
     }
 
     .graph-fallback {
-      width: min(100%, 92rem);
+      width: min(calc(100% - 2.5rem), 92rem);
       margin: 0 auto;
       padding: 1rem;
       border: 1px solid var(--color-border);
@@ -560,15 +560,11 @@ const garphieldOrigin =
 
     @media (max-width: 68rem) {
       #model-description {
-        height: 4.5rem;
+        height: 4.65em;
       }
     }
 
     @media (max-width: 48rem) {
-      .graph-page {
-        padding-inline: 0.5rem;
-      }
-
       .graph-status-row {
         align-items: flex-start;
         flex-direction: column;
@@ -601,6 +597,12 @@ const garphieldOrigin =
 
       #similarity-value {
         min-width: 2.75rem;
+      }
+    }
+
+    @media (max-width: 30rem) {
+      #model-description {
+        height: 6.2em;
       }
     }
 

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -24,32 +24,46 @@ const garphieldOrigin =
           participate in more relationships.
         </p>
       </div>
-      <div class="model-switcher" role="group" aria-label="Graph model">
-        <button
-          type="button"
-          class="model-button active"
-          data-document="/graphs/databases-languages.gfd"
-          data-description="Connect databases to the query languages they support. Larger nodes participate in more relationships."
-          aria-pressed="true"
-        >
-          Query languages
-        </button>
-        <button
-          type="button"
-          class="model-button"
-          data-document="/graphs/databases-similarity.gfd"
-          data-description="Connect each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
-          aria-pressed="false"
-        >
-          Similarity
-        </button>
-      </div>
     </section>
 
     <section class="graph-stage" aria-label="Interactive graph visualization">
       <div class="graph-status-row">
-        <p id="graph-status" role="status">Starting visualization…</p>
-        <p id="graph-selection">Click a node to inspect it.</p>
+        <div class="graph-status-left">
+          <div class="model-switcher" role="group" aria-label="Graph model">
+            <button
+              type="button"
+              class="model-button active"
+              data-document="/graphs/databases-languages.gfd"
+              data-description="Connect databases to the query languages they support. Larger nodes participate in more relationships."
+              aria-pressed="true"
+            >
+              Query languages
+            </button>
+            <button
+              type="button"
+              class="model-button"
+              data-document="/graphs/databases-similarity.gfd"
+              data-description="Connect each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
+              aria-pressed="false"
+            >
+              Similarity
+            </button>
+          </div>
+          <p id="graph-status" role="status">Starting visualization…</p>
+          <label id="similarity-control" hidden>
+            <span>Min similarity</span>
+            <input
+              id="similarity-threshold"
+              type="range"
+              min="0.2"
+              max="0.8"
+              value="0.2"
+              step="0.05"
+            />
+            <output id="similarity-value" for="similarity-threshold">≥ 20%</output>
+          </label>
+        </div>
+        <p id="graph-selection" aria-live="polite" hidden></p>
       </div>
       <iframe
         id="garphield-frame"
@@ -72,29 +86,76 @@ const garphieldOrigin =
     import { createGarphield } from 'garphield';
 
     const page = document.querySelector('.graph-page');
+    const graphStage = document.querySelector('.graph-stage');
     const frame = document.querySelector('#garphield-frame');
     const status = document.querySelector('#graph-status');
     const selection = document.querySelector('#graph-selection');
     const description = document.querySelector('#model-description');
+    const similarityControl = document.querySelector('#similarity-control');
+    const similarityThreshold = document.querySelector('#similarity-threshold');
+    const similarityValue = document.querySelector('#similarity-value');
     const buttons = [...document.querySelectorAll('.model-button')];
 
     if (
       page instanceof HTMLElement &&
+      graphStage instanceof HTMLElement &&
       frame instanceof HTMLIFrameElement &&
       status instanceof HTMLElement &&
       selection instanceof HTMLElement &&
-      description instanceof HTMLElement
+      description instanceof HTMLElement &&
+      similarityControl instanceof HTMLLabelElement &&
+      similarityThreshold instanceof HTMLInputElement &&
+      similarityValue instanceof HTMLOutputElement
     ) {
       const origin = page.dataset.garphieldOrigin ?? 'https://garphield.com';
       const driver = createGarphield(frame, {
         embedUrl: new URL('/embed', origin),
         timeoutMs: 30_000,
       });
-      let labels = new Map();
+      let nodes = new Map();
+      let activeDocument = null;
+      let activeButton = null;
+      let hasRendered = false;
       let loadVersion = 0;
 
+      function clearSelection() {
+        selection.replaceChildren();
+        selection.hidden = true;
+      }
+
       driver.on('nodeClick', (payload) => {
-        selection.textContent = `Selected: ${labels.get(payload.nodeId) ?? payload.nodeId}`;
+        if (!payload.nodeId) {
+          clearSelection();
+          return;
+        }
+        const node = nodes.get(payload.nodeId);
+        if (!node) {
+          clearSelection();
+          return;
+        }
+
+        const label = String(node.label ?? node.id);
+        const content = document.createDocumentFragment();
+        if (typeof node.image === 'string') {
+          const image = document.createElement('img');
+          image.src = node.image;
+          image.alt = '';
+          image.width = 18;
+          image.height = 18;
+          content.append(image);
+        }
+        if (String(node.id).startsWith('db:')) {
+          const link = document.createElement('a');
+          link.href = `/db/${encodeURIComponent(String(node.id).slice(3))}/`;
+          link.textContent = label;
+          content.append(link);
+        } else {
+          const text = document.createElement('span');
+          text.textContent = label;
+          content.append(text);
+        }
+        selection.replaceChildren(content);
+        selection.hidden = false;
       });
       driver.on('error', (payload) => {
         status.textContent = `Visualization error: ${payload.message}`;
@@ -132,16 +193,62 @@ const garphieldOrigin =
       };
       colorScheme.addEventListener('change', systemThemeListener);
 
+      function updateSimilarityLabel() {
+        similarityValue.value = `≥ ${Math.round(Number(similarityThreshold.value) * 100)}%`;
+      }
+
+      function documentForCurrentView(source) {
+        const document = structuredClone(source);
+        if (activeButton?.dataset.document?.includes('similarity')) {
+          const threshold = Number(similarityThreshold.value);
+          const graph = document.datasets[0].graph;
+          graph.links = graph.links.filter(
+            (link) =>
+              typeof link.similarity === 'number' &&
+              link.similarity >= threshold,
+          );
+        }
+        return document;
+      }
+
+      async function renderDocument(source, version) {
+        const shouldFade = hasRendered;
+        if (shouldFade) {
+          graphStage.classList.add('switching');
+          await new Promise((resolve) => window.setTimeout(resolve, 180));
+        }
+
+        const document = documentForCurrentView(source);
+        await syncTheme();
+        await driver.setDocument(document);
+        if (version !== loadVersion) return;
+
+        const graph = document.datasets[0].graph;
+        nodes = new Map(
+          graph.nodes.map((node) => [String(node.id), node]),
+        );
+        status.textContent = `${graph.nodes.length} nodes · ${graph.links.length} relationships`;
+        await new Promise((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(resolve)),
+        );
+        if (version !== loadVersion) return;
+        graphStage.classList.remove('switching');
+        hasRendered = true;
+      }
+
       async function loadDocument(button) {
         const version = ++loadVersion;
+        activeButton = button;
         for (const candidate of buttons) {
           const active = candidate === button;
           candidate.classList.toggle('active', active);
           candidate.setAttribute('aria-pressed', String(active));
         }
         description.textContent = button.dataset.description ?? '';
-        selection.textContent = 'Click a node to inspect it.';
-        status.textContent = `Loading ${button.textContent.trim()}…`;
+        similarityControl.hidden =
+          !button.dataset.document?.includes('similarity');
+        clearSelection();
+        status.textContent = 'Loading…';
 
         try {
           const response = await fetch(button.dataset.document);
@@ -159,22 +266,34 @@ const garphieldOrigin =
               }
             }
           }
-          await syncTheme();
-          await driver.setDocument(document);
           if (version !== loadVersion) return;
-          const graph = document.datasets[0].graph;
-          labels = new Map(
-            graph.nodes.map((node) => [
-              String(node.id),
-              String(node.label ?? node.id),
-            ]),
-          );
-          status.textContent = `${button.textContent.trim()} · ${graph.nodes.length} nodes · ${graph.links.length} relationships`;
+          activeDocument = document;
+          await renderDocument(document, version);
         } catch (error) {
           if (version !== loadVersion) return;
+          graphStage.classList.remove('switching');
           status.textContent = `Could not load visualization: ${String(error)}`;
         }
       }
+
+      updateSimilarityLabel();
+      similarityThreshold.addEventListener('input', updateSimilarityLabel);
+      similarityThreshold.addEventListener('change', () => {
+        if (
+          !activeDocument ||
+          !activeButton?.dataset.document?.includes('similarity')
+        ) {
+          return;
+        }
+        const version = ++loadVersion;
+        clearSelection();
+        status.textContent = 'Updating…';
+        void renderDocument(activeDocument, version).catch((error) => {
+          if (version !== loadVersion) return;
+          graphStage.classList.remove('switching');
+          status.textContent = `Could not update visualization: ${String(error)}`;
+        });
+      });
 
       for (const button of buttons) {
         button.addEventListener('click', () => loadDocument(button));
@@ -207,13 +326,9 @@ const garphieldOrigin =
     .graph-intro {
       width: min(100%, 92rem);
       margin: 0 auto;
-      display: flex;
-      align-items: end;
-      justify-content: space-between;
-      gap: 1.5rem;
     }
 
-    .graph-intro > div:first-child {
+    .graph-intro > div {
       min-width: 0;
     }
 
@@ -226,13 +341,16 @@ const garphieldOrigin =
     }
 
     #model-description {
+      height: 3rem;
+      margin: 0;
+      overflow: hidden;
       max-width: 54rem;
       color: var(--color-text-secondary);
     }
 
     .model-switcher {
       display: flex;
-      padding: 0.25rem;
+      padding: 0.15rem;
       border: 1px solid var(--color-border);
       border-radius: 0.5rem;
       background: var(--color-surface);
@@ -242,7 +360,7 @@ const garphieldOrigin =
     .model-button {
       border: 0;
       border-radius: 0.35rem;
-      padding: 0.55rem 0.8rem;
+      padding: 0.4rem 0.7rem;
       background: transparent;
       color: var(--color-text-secondary);
       cursor: pointer;
@@ -281,12 +399,75 @@ const garphieldOrigin =
       font-size: 0.72rem;
     }
 
+    .graph-status-left {
+      min-width: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    #similarity-control {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      white-space: nowrap;
+    }
+
+    #similarity-control[hidden] {
+      display: none;
+    }
+
+    #similarity-threshold {
+      width: 7rem;
+      accent-color: var(--color-brand);
+    }
+
+    #similarity-value {
+      min-width: 3.25rem;
+      color: var(--color-text);
+    }
+
+    #graph-status,
+    #graph-selection {
+      margin: 0;
+    }
+
+    #graph-selection {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      white-space: nowrap;
+    }
+
+    #graph-selection[hidden] {
+      display: none;
+    }
+
+    #graph-selection img {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      object-fit: contain;
+      background: white;
+    }
+
+    #graph-selection a {
+      color: var(--color-text);
+      text-underline-offset: 0.18em;
+    }
+
     #garphield-frame {
       width: 100%;
       height: 100%;
       min-height: 31rem;
       border: 0;
       background: var(--color-background);
+      opacity: 1;
+      transition: opacity 180ms ease;
+    }
+
+    .graph-stage.switching #garphield-frame {
+      opacity: 0;
     }
 
     .graph-fallback {
@@ -297,15 +478,8 @@ const garphieldOrigin =
     }
 
     @media (max-width: 68rem) {
-      .graph-intro {
-        align-items: stretch;
-        flex-direction: column;
-        justify-content: flex-start;
-        gap: 0.75rem;
-      }
-
-      .model-switcher {
-        align-self: flex-start;
+      #model-description {
+        height: 4.5rem;
       }
     }
 
@@ -317,7 +491,22 @@ const garphieldOrigin =
       .graph-status-row {
         align-items: flex-start;
         flex-direction: column;
-        gap: 0.2rem;
+        gap: 0.4rem;
+      }
+
+      .graph-status-left {
+        flex-wrap: wrap;
+        gap: 0.4rem 0.65rem;
+      }
+
+      #similarity-threshold {
+        width: 6rem;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      #garphield-frame {
+        transition: none;
       }
     }
   </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -233,20 +233,44 @@ header {
   }
 
   @media (max-width: 45rem) {
+    padding-inline: 0.5rem;
+
     div.left {
+      gap: 0.25rem;
 
       .database-summary {
+        display: none;
+      }
+
+      .header-home {
+        margin-right: 0;
+      }
+
+      .header-brand {
+        display: none;
+      }
+    }
+
+    div.right {
+      gap: 0.375rem;
+
+      .search-container {
         display: none;
       }
     }
   }
 
-  @media (max-width: 45rem) {
-    div.right {
+  @media (max-width: 22rem) {
+    #help {
+      width: 2rem;
+      padding-inline: 0;
+      justify-content: center;
+      font-size: 0;
+    }
 
-      .search-container {
-        display: none;
-      }
+    #help::before {
+      content: '?';
+      font-size: 0.8125rem;
     }
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -33,6 +33,13 @@
   --color-text-invert: #FFF;
   --color-text-secondary: #666;
   --color-text-tertiary: #767676;
+  --site-background:
+    radial-gradient(
+      circle at 15% 10%,
+      color-mix(in srgb, var(--color-brand) 14%, transparent),
+      transparent 28rem
+    ),
+    var(--color-background);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -70,7 +77,12 @@ body {
   font-family: 'Rubik', sans-serif;
   line-height: 1.6;
   color: var(--color-text);
-  background-color: var(--color-background);
+  background: var(--site-background);
+  background-attachment: fixed;
+}
+
+body {
+  min-height: 100vh;
 }
 
 body:has(dialog[open]) {
@@ -103,7 +115,9 @@ header {
   align-items: center;
   height: var(--header-height);
   padding: 0 0.75rem;
-  background-color: var(--color-background);
+  background-color: color-mix(in srgb, var(--color-background) 78%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  backdrop-filter: blur(16px) saturate(1.1);
   position: fixed;
   width: 100%;
   z-index: 20;
@@ -368,6 +382,8 @@ th.rank-col { padding-left: 0.5rem; padding-right: 0.5rem; }
   color: var(--color-background);
 }
 .rankings-link__icon { flex-shrink: 0; }
+.graph-link { gap: 0.35rem; }
+.graph-link__icon { flex-shrink: 0; }
 @media (max-width: 45rem) {
   .rankings-link__label { display: none; }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1023,4 +1023,3 @@ thead [role="tooltip"]::after {
   gap: 1rem;
   margin-top: 0.5rem;
 }
-


### PR DESCRIPTION
## Summary
- add a full-page Garphield visualization with query-language and database-similarity views
- render database favicons, stable live similarity filtering, selection links, and responsive controls
- preload and decode node artwork before display to avoid favicon pop-in
- add shared navigation for the map plus the site-wide gradient and translucent header treatment
- regenerate map documents with the current 145-database catalog, including TypeGraph

## Garphield integration
- embeds the hosted Garphield application directly rather than using an iframe-only integration surface
- uses the public `garphield@0.1.1` driver and the render controls merged in ammil-industries/garphield#200
- keeps the experimental type-hull UI out of this PR

## Verification
- `npm run build`: 151 static pages built
- query-language map: 145 databases, 41 query languages, 208 supported pairings
- similarity map: 145 databases, 324 database pairings at the default threshold
- verified locally on desktop and mobile in light and dark themes
- verified instant threshold updates preserve node positions and outlined-label performance during pan