### PR TITLE
Sort unranked rows to the bottom of the rank column

### DIFF
--- a/src/scripts/table.ts
+++ b/src/scripts/table.ts
@@ -204,8 +204,15 @@ function getCellValue(
   }
 
   const text = cell.textContent?.trim() || "";
-  if (text === "-") return undefined;
-  if (type === "number") return parseFloat(text.replace(/[$,]/g, "")) || 0;
+  // Empty cells render an em-dash. The original check looked for a plain hyphen, so it
+  // never matched and unranked rows fell through to `parseFloat("—") || 0`, sorting them
+  // above rank 1. `undefined` is what the comparator sends to the bottom in both
+  // directions, so anything unparseable returns it rather than collapsing to zero.
+  if (text === "" || text === "-" || text === "\u2014") return undefined;
+  if (type === "number") {
+    const value = parseFloat(text.replace(/[$,]/g, ""));
+    return Number.isNaN(value) ? undefined : value;
+  }
   return text;
 }
 


### PR DESCRIPTION
Sorting by Rank put the 10 unranked engines above rank 1.

`getCellValue` tested `text === "-"` for empty cells, but the table renders an em-dash. The check never matched, so those cells fell through to `parseFloat("—") || 0` and sorted as rank 0.

Now returns `undefined` for empty cells and for anything a number column can't parse — the comparator already sends `undefined` to the bottom in both directions, so no change was needed there.

Verified in a browser against the built site, same two clicks on the Rank header:

| | Top | Bottom |
|---|---|---|
| before | `—` `—` `—` `—` `—` | 133, 134, 135 |
| after | 1, 2, 3, 4 | `—` `—` `—` |
