### PR TITLE
Polish graph loading, mobile layout, and sponsorship

### DIFF
--- a/src/components/SponsorCTA.astro
+++ b/src/components/SponsorCTA.astro
@@ -1,21 +1,56 @@
----
-// Single sponsorship/advertising blurb shared across the rankings pages.
----
-<aside class="sponsor-cta">
-  We strive to be the best resource to compare graph databases. For sponsorship and advertising enquiries: <a href="/sponsor/">get in touch</a>.
+<aside class="sponsor-cta" aria-label="Sponsor GDB-Engines">
+  <span>
+    <strong>Reach teams choosing their next graph database.</strong>
+    Put your product in front of the people comparing the market.
+  </span>
+  <a href="/sponsor/">Sponsor GDB-Engines <span aria-hidden="true">→</span></a>
 </aside>
 
 <style>
   .sponsor-cta {
-    background: var(--color-surface);
-    border-left: 3px solid var(--color-border);
-    padding: 1rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    max-width: 90ch;
     margin: 0.5rem 0 1.5rem;
+    padding: 0.8rem 0.9rem 0.8rem 1rem;
+    background:
+      linear-gradient(
+        110deg,
+        color-mix(in srgb, var(--color-brand) 20%, var(--color-surface)),
+        color-mix(in srgb, var(--color-brand) 7%, var(--color-background))
+      );
+    border: 1px solid color-mix(in srgb, var(--color-brand-accent) 38%, var(--color-border));
+    border-radius: 0.6rem;
     font-size: 0.85rem;
-    line-height: 1.55;
+    line-height: 1.45;
     color: var(--color-text-secondary);
-    max-width: 70ch;
   }
-  .sponsor-cta a { color: var(--color-text); text-decoration: none; margin-left: 0.25rem; }
-  .sponsor-cta a:hover { text-decoration: underline; }
+
+  .sponsor-cta strong {
+    color: var(--color-text);
+  }
+
+  .sponsor-cta a {
+    flex: 0 0 auto;
+    padding: 0.42rem 0.7rem;
+    border-radius: 0.4rem;
+    background: var(--color-brand-accent);
+    color: var(--color-background);
+    font-weight: 600;
+    text-decoration: none;
+  }
+
+  .sponsor-cta a:hover {
+    filter: brightness(1.06);
+  }
+
+  @media (max-width: 32rem) {
+    .sponsor-cta {
+      align-items: flex-start;
+      flex-direction: column;
+      gap: 0.65rem;
+    }
+  }
 </style>

--- a/src/pages/compare/index.astro
+++ b/src/pages/compare/index.astro
@@ -10,6 +10,7 @@ import Layout from '../../layouts/Layout.astro';
 import SiteHeader from '../../components/SiteHeader.astro';
 import CountBadge from '../../components/CountBadge.astro';
 import CompareCombobox from '../../components/CompareCombobox.astro';
+import SponsorCTA from '../../components/SponsorCTA.astro';
 import '../../styles/global.css';
 import { getCollection } from 'astro:content';
 import { buildFaviconMap } from '../../lib/favicon-map';
@@ -101,6 +102,7 @@ const breadcrumbJsonLd = JSON.stringify({
       shows rank, license, query languages, implementation language and academic research details where
       available.
     </p>
+    <SponsorCTA />
 
     <section class="group build">
       <h2>Build your own</h2>

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SiteHeader from '../components/SiteHeader.astro';
+import SponsorCTA from '../components/SponsorCTA.astro';
 import { getDatabaseCount } from '../lib/database-count';
 import '../styles/global.css';
 
@@ -22,6 +23,7 @@ const garphieldOrigin =
         <p id="model-description">
           Databases linked via query languages supported.
         </p>
+        <SponsorCTA />
       </div>
     </section>
 
@@ -34,6 +36,7 @@ const garphieldOrigin =
               class="model-button active"
               data-document="/graphs/databases-languages.gfd"
               data-description="Databases linked via query languages supported."
+              data-mobile-description="Databases linked via query languages supported."
               aria-pressed="true"
             >
               Query languages
@@ -43,6 +46,7 @@ const garphieldOrigin =
               class="model-button"
               data-document="/graphs/databases-similarity.gfd"
               data-description="Link each database to its nearest catalog peers using type, kind, category, license, implementation language, and query languages."
+              data-mobile-description="Databases linked to their nearest catalog peers."
               aria-pressed="false"
             >
               Similarity
@@ -206,6 +210,7 @@ const garphieldOrigin =
 
       const ready = driver.ready();
       const colorScheme = window.matchMedia('(prefers-color-scheme: dark)');
+      const compactLayout = window.matchMedia('(max-width: 48rem)');
 
       function effectiveTheme(): 'light' | 'dark' {
         const explicit = document.documentElement.dataset.theme;
@@ -238,6 +243,14 @@ const garphieldOrigin =
 
       function updateSimilarityLabel() {
         similarityValue.value = `≥ ${Math.round(Number(similarityThreshold.value) * 100)}%`;
+      }
+
+      function updateDescription() {
+        if (!activeButton) return;
+        description.textContent =
+          (compactLayout.matches
+            ? activeButton.dataset.mobileDescription
+            : activeButton.dataset.description) ?? '';
       }
 
       function updateGraphStatus(graph, visibleLinks = graph.links.length) {
@@ -308,6 +321,7 @@ const garphieldOrigin =
           requestAnimationFrame(() => requestAnimationFrame(resolve)),
         );
         if (version !== loadVersion) return;
+        graphStage.classList.add('ready');
         graphStage.classList.remove('switching');
         hasRendered = true;
       }
@@ -320,7 +334,7 @@ const garphieldOrigin =
           candidate.classList.toggle('active', active);
           candidate.setAttribute('aria-pressed', String(active));
         }
-        description.textContent = button.dataset.description ?? '';
+        updateDescription();
         similarityControl.hidden =
           !button.dataset.document?.includes('similarity');
         clearSelection();
@@ -356,6 +370,7 @@ const garphieldOrigin =
       }
 
       updateSimilarityLabel();
+      compactLayout.addEventListener('change', updateDescription);
       similarityThreshold.addEventListener('input', () => {
         updateSimilarityLabel();
         scheduleSimilarityFilter();
@@ -369,6 +384,7 @@ const garphieldOrigin =
         () => {
           themeObserver.disconnect();
           colorScheme.removeEventListener('change', systemThemeListener);
+          compactLayout.removeEventListener('change', updateDescription);
           if (similarityFilterFrame !== 0) {
             cancelAnimationFrame(similarityFilterFrame);
           }
@@ -543,8 +559,12 @@ const garphieldOrigin =
       min-height: 31rem;
       border: 0;
       background: var(--color-background);
-      opacity: 1;
+      opacity: 0;
       transition: opacity 180ms ease;
+    }
+
+    .graph-stage.ready #garphield-frame {
+      opacity: 1;
     }
 
     .graph-stage.switching #garphield-frame {
@@ -565,6 +585,10 @@ const garphieldOrigin =
     }
 
     @media (max-width: 48rem) {
+      #model-description {
+        height: 3.1em;
+      }
+
       .graph-status-row {
         align-items: flex-start;
         flex-direction: column;
@@ -597,12 +621,6 @@ const garphieldOrigin =
 
       #similarity-value {
         min-width: 2.75rem;
-      }
-    }
-
-    @media (max-width: 30rem) {
-      #model-description {
-        height: 6.2em;
       }
     }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import SiteHeader from '../components/SiteHeader.astro';
+import SponsorCTA from '../components/SponsorCTA.astro';
 import '../styles/global.css';
 import { getCollection } from 'astro:content';
 import { featureGroups, featureDisplayNames, columnTooltips } from '../data/feature-metadata';
@@ -76,6 +77,10 @@ const datasetJsonLd = JSON.stringify({
   <SiteHeader comparisonControls />
 
   <h1 class="sr-only">Graph Database Comparison — {databases.length}+ Engines</h1>
+
+  <div class="home-sponsor">
+    <SponsorCTA />
+  </div>
 
   <table>
     <thead>
@@ -305,3 +310,15 @@ const datasetJsonLd = JSON.stringify({
   </dialog>
   <script src="../scripts/table.ts"></script>
 </Layout>
+
+<style>
+  .home-sponsor {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding: calc(var(--header-height) + 1rem) 1.25rem 0;
+  }
+
+  .home-sponsor + table {
+    margin-top: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- hide the Garphield iframe until its first themed document has rendered, preventing dark-mode white flash
- keep mobile model descriptions to a stable two-line height with concise responsive copy
- add a punchier shared sponsorship banner to Rankings, Map, and Compare

## Verification
- npm run build (180 pages)
- git diff --check
- verified light/dark initial render through a local Garphield embed
- verified 420px Query Languages → Similarity switch keeps the graph stage at the same vertical position
- visually checked Rankings, Map, and Compare at 420px and Map at 1280px