### PR TITLE
Keep rank and name visible while scrolling tables

### DIFF
--- a/src/components/RankingTable.astro
+++ b/src/components/RankingTable.astro
@@ -52,9 +52,9 @@ const tierClass = (tier: string): string => {
   <table class="ranking-table">
     <thead>
       <tr>
-        <th class="num rank-cell">#</th>
+        <th class="num rank-cell sticky-rank-column">#</th>
         {hasDeltas && <th class="num">1mo</th>}
-        <th>Name</th>
+        <th class="sticky-name-column">Name</th>
         <th class="num">{scoreLabel}</th>
         <th>Tier</th>
         <th class="hide-mobile">Type</th>
@@ -71,9 +71,9 @@ const tierClass = (tier: string): string => {
         const langSlug = e.implementationLanguage ? linkMaps?.implementationLanguageSlug.get(e.implementationLanguage) : null;
         return (
           <tr>
-            <td class="num rank-cell">{i + 1}</td>
+            <td class="num rank-cell sticky-rank-column">{i + 1}</td>
             {hasDeltas && <td class={`num ${deltaClass(e.rankDelta1m)}`}>{fmtDelta(e.rankDelta1m)}</td>}
-            <td>
+            <td class="sticky-name-column">
               <div class="name-cell">
                 {fav && <img src={fav} alt="" width="16" height="16" class="favicon" loading="lazy" />}
                 <a href={`/db/${e.slug}/`} class="has-tooltip" aria-label={engineMeta[e.slug]?.description ?? e.name} data-microtip-position="top-right" data-microtip-size="medium" role="tooltip">{e.name}</a>
@@ -147,11 +147,18 @@ const tierClass = (tier: string): string => {
     margin-top: 0;
     width: max-content;
     min-width: 100%;
+    --sticky-name-left: 2.25rem;
   }
   /* No top-level site header on ranking pages, so anchor the sticky header to viewport top. */
   .ranking-table thead th { top: 0; }
   .ranking-table .num { text-align: right; font-variant-numeric: tabular-nums; }
-  .ranking-table .rank-cell { padding-left: 0.5rem; padding-right: 0.5rem; width: 2.25rem; }
+  .ranking-table .rank-cell {
+    width: 2.25rem;
+    min-width: 2.25rem;
+    max-width: 2.25rem;
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
   .ranking-table a { color: inherit; text-decoration: none; }
   .ranking-table a:hover { text-decoration: underline; }
   /* Match the homepage's Name cell layout — favicon + tooltipped link + db-links

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,8 +87,8 @@ const datasetJsonLd = JSON.stringify({
     <table>
     <thead>
       <tr>
-        {linkMaps && <th class="sortable rank-col" data-type="number"><div class="header-container"><span class="has-tooltip" aria-label="Position in the overall Graph Database Popularity Ranking" data-microtip-position="bottom-right" role="tooltip">Rank</span> <span class="sort-indicator">↑</span></div></th>}
-        <th class="sortable" data-type="text"><div class="header-container"><span class="has-tooltip" aria-label={columnTooltips.name} data-microtip-position="bottom-right" role="tooltip">Name</span> <span class="sort-indicator"></span></div></th>
+        {linkMaps && <th class="sortable rank-col sticky-rank-column" data-type="number"><div class="header-container"><span class="has-tooltip" aria-label="Position in the overall Graph Database Popularity Ranking" data-microtip-position="bottom-right" role="tooltip">Rank</span> <span class="sort-indicator">↑</span></div></th>}
+        <th class:list={["sortable", linkMaps && "sticky-name-column"]} data-type="text"><div class="header-container"><span class="has-tooltip" aria-label={columnTooltips.name} data-microtip-position="bottom-right" role="tooltip">Name</span> <span class="sort-indicator"></span></div></th>
         {hasGithubRepositories && (
           <th class="sortable github-col" data-type="number">
             <div class="header-container">
@@ -123,7 +123,7 @@ const datasetJsonLd = JSON.stringify({
       {databases.map(db => (
         <tr class={db.data.status !== 'active' ? `row-${db.data.status}` : ''} data-previous-vendors={db.data.previous_vendors?.join(',') || ''} data-previous-names={db.data.previous_names?.join(',') || ''}>
           {linkMaps && (
-            <td class="rank-col">{linkMaps.overallRank.has(db.data.slug)
+            <td class="rank-col sticky-rank-column">{linkMaps.overallRank.has(db.data.slug)
               ? (() => {
                   const rank = linkMaps.overallRank.get(db.data.slug);
                   const d = linkMaps.overallDelta1m.get(db.data.slug);
@@ -143,7 +143,7 @@ const datasetJsonLd = JSON.stringify({
                 })()
               : <span class="rank-link"><span class="rank-num rank-empty">—</span><span class="rank-delta"></span></span>}</td>
           )}
-          <td>
+          <td class:list={[linkMaps && "sticky-name-column"]}>
             <div class="database-cell">
               {(() => {
                 const fav = faviconMap[db.data.slug];

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -577,6 +577,44 @@ table thead th {
   z-index: 10;
 }
 
+/* Keep the identifying columns in view while wide tables scroll horizontally.
+   Each table can override --sticky-name-left to match its rank-column width. */
+table {
+  --sticky-name-left: 4.5rem;
+}
+
+/* Table layout may otherwise grow the rank column to accommodate spare width,
+   which would make the name column's fixed sticky offset overlap it. */
+table .rank-col {
+  width: 4.5rem;
+  min-width: 4.5rem;
+  max-width: 4.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+
+table tbody .sticky-rank-column,
+table tbody .sticky-name-column {
+  position: sticky;
+  z-index: 2;
+  background-color: var(--color-background);
+}
+
+table .sticky-rank-column {
+  left: 0;
+}
+
+table .sticky-name-column {
+  left: var(--sticky-name-left);
+  box-shadow: 1px 0 0 var(--color-border);
+}
+
+table thead th.sticky-rank-column,
+table thead th.sticky-name-column {
+  z-index: 11;
+  background-color: var(--color-background);
+}
+
 table thead th .header-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- keep the rank and name columns visible while horizontally scrolling the homepage catalogue
- apply the same frozen-column behavior to ranking board tables
- lock rank widths and layer opaque sticky cells to prevent overlap and content bleed-through

## Testing

- `npm run build`
- browser-tested horizontal scrolling on `/` and `/rankings/overall/` at a 390px viewport