### PR TITLE
Track databases in comparison analytics

### DIFF
--- a/docs/design/comparison-pages.md
+++ b/docs/design/comparison-pages.md
@@ -923,22 +923,32 @@ mechanism is deliberately manual — a monthly read, not a pipeline.
 permits that host in both `script-src` and `connect-src`. Seline supports custom events, so
 no new vendor, no new CSP entry, no cookie banner question to reopen.
 
-**One event.** On `/compare/custom/`, once per page view, debounced 2s after the last
-selection change so intermediate states are not counted:
+**One event schema.** Every rendered comparison sends the same event. Pair and roundup
+pages send it when the page loads; `/compare/custom/` sends it for an initial URL selection
+and then debounces later selection changes by 2s so intermediate states are not counted:
 
 ```js
-seline.track('compare_custom', { engines: sorted.join(','), count: sorted.length });
+seline.track('comparison: viewed', {
+  databases: sorted.join(','),
+  count: sorted.length,
+  surface: 'pair' | 'roundup' | 'custom',
+  database_1: sorted[0],
+  database_2: sorted[1],
+  // database_3 ... database_6 when present
+});
 ```
 
-`engines` is the alphabetically sorted slug list, so `a,b` and `b,a` aggregate to one row.
-Nothing else is collected — no free-text, no partial input from the combobox.
+`databases` is the alphabetically sorted slug list, so `a,b` and `b,a` aggregate to one
+row. The positional properties make individual slugs filterable without parsing the list.
+Nothing else is collected — no free-text, no partial input from the combobox. Calls wait
+for the asynchronous Seline script instead of being dropped when it is still loading.
 
 **Search Console** covers the other half: queries and impressions for `/compare/*`, which
 catches demand for combinations nobody reached the builder to try.
 
 **The monthly review**, done by hand alongside the existing rankings refresh:
 
-1. Top `compare_custom` combinations of `count == 2` → if any sits outside the
+1. Top `comparison: viewed` combinations with `surface == custom` and `count == 2` → if any sits outside the
    pre-generated set with meaningful volume, it is a signal that `peerDepth` or
    `anchorDepth` is set too low. Adjust the constant rather than allowlisting the pair —
    one number is easier to reason about than a growing list of exceptions.
@@ -996,7 +1006,7 @@ should land first within this phase.
 - `_redirects` splat rule, **verified on a preview deployment**.
 - Raise `peerDepth` to 40 and `anchorDepth` to 10 → **1,455 pages** after the gate.
 - Related-comparison cross-links; `llms.txt` section; `Show only differing rows` toggle.
-- The `compare_custom` Seline event (§7).
+- The `comparison: viewed` Seline event across pair, roundup and custom surfaces (§7).
 
 **Phase 3 — conditional on evidence.**
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -73,6 +73,7 @@ const siteSchema = JSON.stringify({
     ))}
     {selineToken && (
       <script
+        id="seline-script"
         src="https://sln.gdb-engines.com/ennui.js"
         data-api-host="https://sln.gdb-engines.com"
         data-token={selineToken}

--- a/src/pages/compare/[entry].astro
+++ b/src/pages/compare/[entry].astro
@@ -341,7 +341,11 @@ const tableMembers = !isPair ? members.filter((m) => !engines.some((e) => e.slug
 ---
 <Layout title={title} description={description} canonical={canonical} jsonLd={[itemListJsonLd, breadcrumbJsonLd]}>
   <SiteHeader />
-  <main class="compare-page">
+  <main
+    class="compare-page"
+    data-comparison-databases={engines.map((engine) => engine.slug).join(',')}
+    data-comparison-surface={isPair ? 'pair' : 'roundup'}
+  >
     <nav class="breadcrumb"><a href="/compare/">Comparisons</a> &rsaquo; {h1}</nav>
     <h1>{h1}</h1>
     {!isPair && <p class="lede">{def.lede}</p>}
@@ -546,6 +550,15 @@ const tableMembers = !isPair ? members.filter((m) => !engines.some((e) => e.slug
 </Layout>
 
 <script>
+  import { trackDatabaseComparison, type ComparisonSurface } from '../../scripts/seline';
+
+  const comparison = document.querySelector<HTMLElement>('[data-comparison-databases]');
+  if (comparison) {
+    const databases = comparison.dataset.comparisonDatabases?.split(',').filter(Boolean) ?? [];
+    const surface = comparison.dataset.comparisonSurface as ComparisonSurface;
+    trackDatabaseComparison(databases, surface);
+  }
+
   // JS-only and default off, so the full matrix is always in the served HTML.
   const toggle = document.querySelector<HTMLInputElement>('[data-differ-toggle]');
   const matrix = document.querySelector<HTMLElement>('[data-feature-matrix]');

--- a/src/scripts/compare-builder.ts
+++ b/src/scripts/compare-builder.ts
@@ -8,6 +8,7 @@
  */
 import { featureGroups, featureDisplayNames, featureKeys } from '../data/feature-metadata';
 import { formatCompactCount } from '../lib/format-number';
+import { trackDatabaseComparison } from './seline';
 
 interface Engine {
   slug: string;
@@ -102,10 +103,7 @@ async function mount(root: HTMLElement): Promise<void> {
   function track(): void {
     window.clearTimeout(trackTimer);
     trackTimer = window.setTimeout(() => {
-      const seline = (window as unknown as { seline?: { track: (n: string, p: unknown) => void } }).seline;
-      if (!seline || selected.length < 2) return;
-      const sorted = [...selected].sort();
-      seline.track('compare_custom', { engines: sorted.join(','), count: sorted.length });
+      trackDatabaseComparison(selected, 'custom');
     }, 2000);
   }
 
@@ -385,4 +383,5 @@ async function mount(root: HTMLElement): Promise<void> {
   renderChips();
   renderList();
   renderColumns();
+  if (!staticPage) track();
 }

--- a/src/scripts/seline.ts
+++ b/src/scripts/seline.ts
@@ -1,0 +1,58 @@
+type SelineProperty = string | number | boolean;
+
+interface SelineClient {
+  track: (name: string, properties: Record<string, SelineProperty>) => void;
+}
+
+declare global {
+  interface Window {
+    seline?: SelineClient;
+  }
+}
+
+const pending = new Map<string, Record<string, SelineProperty>>();
+let waitingForScript = false;
+
+function flush(): boolean {
+  if (!window.seline) return false;
+  for (const [name, properties] of pending) window.seline.track(name, properties);
+  pending.clear();
+  return true;
+}
+
+/**
+ * Seline loads asynchronously. Keep the latest event of each name until its script is
+ * ready, rather than silently losing events on a cold cache or slow connection.
+ */
+function track(name: string, properties: Record<string, SelineProperty>): void {
+  pending.set(name, properties);
+  if (flush() || waitingForScript) return;
+
+  const script = document.querySelector<HTMLScriptElement>('#seline-script');
+  if (!script) return;
+
+  waitingForScript = true;
+  script.addEventListener('load', () => {
+    waitingForScript = false;
+    flush();
+  }, { once: true });
+}
+
+export type ComparisonSurface = 'pair' | 'roundup' | 'custom';
+
+/** Track the database set shown together, using catalogue slugs as stable identifiers. */
+export function trackDatabaseComparison(slugs: string[], surface: ComparisonSurface): void {
+  const databases = [...new Set(slugs)].sort();
+  if (databases.length < 2) return;
+
+  const properties: Record<string, SelineProperty> = {
+    databases: databases.join(','),
+    count: databases.length,
+    surface,
+  };
+  databases.forEach((slug, index) => {
+    properties[`database_${index + 1}`] = slug;
+  });
+
+  track('comparison: viewed', properties);
+}


### PR DESCRIPTION
Summary:
- track database sets across pair, roundup, and custom comparisons
- queue events until the asynchronous Seline script is ready
- document the unified comparison event schema

Test:
- Astro production build with Seline enabled