### PR TITLE
Fix tooltips behind sticky ranking rows

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -605,6 +605,13 @@ table tbody .sticky-name-column {
   background-attachment: fixed;
 }
 
+/* A tooltip cannot escape the stacking context created by its sticky cell. Raise
+   the active Name cell above the sticky cells in later rows so they do not mask it. */
+table tbody .sticky-name-column:hover,
+table tbody .sticky-name-column:focus-within {
+  z-index: 3;
+}
+
 table .sticky-rank-column {
   left: 0;
 }


### PR DESCRIPTION
Fixes ranking-table tooltips being masked by later sticky Name cells. Raises the active cell on hover and keyboard focus. Verified with an Astro production build.