### PR TITLE
Enlarge the header menu icon

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1035,12 +1035,14 @@ tr.row-deprecated:hover td {
 .icon-btn:hover {
   color: var(--color-text);
 }
-.site-header .icon-btn {
+.site-header .icon-btn,
+.site-header .menu-btn {
   width: 2.5rem;
   height: 2rem;
 }
 .site-header .icon-btn .icon-sun,
-.site-header .icon-btn .icon-moon {
+.site-header .icon-btn .icon-moon,
+.site-header .menu-btn svg {
   width: 1.75rem;
   height: 1.75rem;
   stroke-width: 2.5;


### PR DESCRIPTION
## Summary
- match the hamburger control width to the theme control
- match the hamburger SVG size and stroke weight to the theme icons

## Verification
- checked locally in light and dark themes
- verified the options dropdown still opens and stays within the viewport
- npm run build