### PR TITLE
Polish the responsive header and mobile sponsorship

### DIFF
--- a/docs/superpowers/plans/2026-08-13-left-aligned-compact-header.md
+++ b/docs/superpowers/plans/2026-08-13-left-aligned-compact-header.md
@@ -1,0 +1,116 @@
+# Left-Aligned Compact Header Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Group the compact logo and primary-navigation icons at the left edge while keeping theme, About, and Options pinned to the right.
+
+**Architecture:** Preserve the existing two-group flex header and all current responsive breakpoints. Change only the compact primary navigation's main-axis alignment at `max-width: 36rem`; its flexible container continues to occupy the space between the logo and utilities, but its three links stop distributing themselves across that space.
+
+**Tech Stack:** Astro, nested CSS in `src/styles/global.css`, in-app browser geometry assertions, Astro production build
+
+## Global Constraints
+
+- At and below `36rem` (576px), the left group is logo, Rankings, Graph, and Compare in that order.
+- Compact navigation labels remain hidden and the home link remains logo-only.
+- The compact primary navigation uses the existing `0.25rem` (4px) gap between links.
+- Theme, About, and Options remain a separate group pinned to the right edge.
+- The `39rem`, `55rem`, and `22rem` responsive behaviors remain unchanged.
+- Do not change the sponsorship pane, search-field breakpoint, control sizing, or accessible labels.
+- Add no dependencies and create no new production component.
+
+---
+
+### Task 1: Left-align the compact primary navigation
+
+**Files:**
+- Modify: `src/styles/global.css:270-290`
+- Test: no persistent test file; use a browser geometry regression assertion because the repository has no browser-test framework
+
+**Interfaces:**
+- Consumes: existing `.site-header`, `.left`, `.primary-nav`, `.rankings-link`, and `.right` flex layout
+- Produces: compact `.primary-nav` content aligned with `justify-content: flex-start` at `max-width: 36rem`
+
+- [ ] **Step 1: Run a failing compact-alignment regression assertion**
+
+With the local site open at `/`, claim the preview tab as `tab` and create a viewport-capability binding as `viewport`. Run this assertion at the exact compact breakpoint and representative smaller widths:
+
+```js
+const widths = [576, 532, 375, 320];
+const failures = [];
+
+for (const width of widths) {
+  await viewport.set({ width, height: 700 });
+  const state = await tab.playwright.evaluate(() => {
+    const nav = document.querySelector('.primary-nav').getBoundingClientRect();
+    const links = [...document.querySelectorAll('.primary-nav .rankings-link')]
+      .map((element) => element.getBoundingClientRect());
+    const utilities = document.querySelector('.site-header > .right').getBoundingClientRect();
+
+    return {
+      width: innerWidth,
+      leadingGap: links[0].left - nav.left,
+      linkGaps: links.slice(1).map((link, index) => link.left - links[index].right),
+      navigationRight: links.at(-1).right,
+      utilitiesLeft: utilities.left,
+    };
+  });
+
+  const linksStartAtLeft = Math.abs(state.leadingGap) <= 0.5;
+  const linksUseCompactGap = state.linkGaps.every((gap) => Math.abs(gap - 4) <= 0.5);
+  const groupsDoNotOverlap = state.navigationRight <= state.utilitiesLeft;
+
+  if (!linksStartAtLeft || !linksUseCompactGap || !groupsDoNotOverlap) failures.push(state);
+}
+
+if (failures.length) throw new Error(`Compact header alignment failed: ${JSON.stringify(failures)}`);
+```
+
+Expected: FAIL because `space-evenly` creates viewport-dependent leading and inter-link gaps.
+
+- [ ] **Step 2: Implement the minimal compact-layout change**
+
+In the existing `@media (max-width: 36rem)` block, change only the primary navigation alignment:
+
+```css
+.primary-nav {
+  flex: 1 1 auto;
+  justify-content: flex-start;
+  gap: 0.25rem;
+}
+```
+
+- [ ] **Step 3: Rerun the browser regression assertion**
+
+Run the Step 1 assertion unchanged.
+
+Expected: PASS at 576, 532, 375, and 320px. `leadingGap` is within 0.5px of zero, each inter-link gap is within 0.5px of 4px, and the last navigation link does not cross the utility group's left edge.
+
+- [ ] **Step 4: Visually verify the compact and adjacent layouts**
+
+Capture light-mode screenshots at 577, 576, 532, 375, and 320px and a dark-mode screenshot at 532px.
+
+Expected:
+
+- At 577px, labelled navigation remains unchanged.
+- At 576px and below, logo and navigation icons read as one left-aligned group.
+- Theme, About, and Options remain aligned as the right group.
+- No controls overlap or clip, and the sponsorship pane remains in normal flow.
+
+- [ ] **Step 5: Run repository verification**
+
+Run:
+
+```bash
+git diff --check
+npm run build
+```
+
+Expected: `git diff --check` exits 0. The build reports 145/145 evidence entries with 0 errors, produces 1,757 pages, and completes successfully; the existing evidence-refetch warnings may remain.
+
+- [ ] **Step 6: Commit the implementation**
+
+```bash
+git add src/styles/global.css
+git commit -m "Left-align compact header navigation"
+```
+

--- a/docs/superpowers/plans/2026-08-13-left-aligned-compact-header.md
+++ b/docs/superpowers/plans/2026-08-13-left-aligned-compact-header.md
@@ -2,25 +2,26 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Group the compact logo and primary-navigation icons at the left edge while keeping theme, About, and Options pinned to the right.
+**Goal:** Group the compact brand and primary-navigation icons at the left edge while keeping theme, About, and Options pinned to the right, and preserve the wordmark for every width where it fits.
 
-**Architecture:** Preserve the existing two-group flex header and all current responsive breakpoints. Change only the compact primary navigation's main-axis alignment at `max-width: 36rem`; its flexible container continues to occupy the space between the logo and utilities, but its three links stop distributing themselves across that space.
+**Architecture:** Preserve the existing two-group flex header. At `max-width: 39rem`, hide the navigation labels and align the icon links from the left while retaining the wordmark. Hide the wordmark only at `max-width: 27rem`. Keep the search cutoff at `55rem`, but hide the database summary through `64rem` so it cannot collapse beside the search field.
 
 **Tech Stack:** Astro, nested CSS in `src/styles/global.css`, in-app browser geometry assertions, Astro production build
 
 ## Global Constraints
 
-- At and below `36rem` (576px), the left group is logo, Rankings, Graph, and Compare in that order.
-- Compact navigation labels remain hidden and the home link remains logo-only.
+- At and below `39rem` (624px), the left group is logo, wordmark, Rankings, Graph, and Compare in that order.
+- Compact navigation labels remain hidden; the wordmark remains visible through 433px and hides at 432px.
 - The compact primary navigation uses the existing `0.25rem` (4px) gap between links.
 - Theme, About, and Options remain a separate group pinned to the right edge.
-- The `39rem`, `55rem`, and `22rem` responsive behaviors remain unchanged.
-- Do not change the sponsorship pane, search-field breakpoint, control sizing, or accessible labels.
+- The compact sponsorship pane remains visible through `39rem`, the search field remains hidden through `55rem`, and the About control retains its `22rem` treatment.
+- The database summary is hidden through `64rem` so the search boundary has no clipped-text sliver.
+- Do not change control sizing or accessible labels.
 - Add no dependencies and create no new production component.
 
 ---
 
-### Task 1: Left-align the compact primary navigation
+### Task 1: Left-align and stage the compact header
 
 **Files:**
 - Modify: `src/styles/global.css:270-290`
@@ -28,14 +29,14 @@
 
 **Interfaces:**
 - Consumes: existing `.site-header`, `.left`, `.primary-nav`, `.rankings-link`, and `.right` flex layout
-- Produces: compact `.primary-nav` content aligned with `justify-content: flex-start` at `max-width: 36rem`
+- Produces: compact `.primary-nav` content aligned with `justify-content: flex-start` at `max-width: 39rem`, with the wordmark retained through 433px
 
 - [ ] **Step 1: Run a failing compact-alignment regression assertion**
 
 With the local site open at `/`, claim the preview tab as `tab` and create a viewport-capability binding as `viewport`. Run this assertion at the exact compact breakpoint and representative smaller widths:
 
 ```js
-const widths = [576, 532, 375, 320];
+const widths = [624, 532, 440, 433, 432, 375, 320];
 const failures = [];
 
 for (const width of widths) {
@@ -65,11 +66,11 @@ for (const width of widths) {
 if (failures.length) throw new Error(`Compact header alignment failed: ${JSON.stringify(failures)}`);
 ```
 
-Expected: FAIL because `space-evenly` creates viewport-dependent leading and inter-link gaps.
+Expected: FAIL because the previous compact treatment starts too late and hides the wordmark too early.
 
-- [ ] **Step 2: Implement the minimal compact-layout change**
+- [ ] **Step 2: Implement the staged compact layout**
 
-In the existing `@media (max-width: 36rem)` block, change only the primary navigation alignment:
+At `max-width: 39rem`, hide navigation labels and align the compact navigation from the left:
 
 ```css
 .primary-nav {
@@ -79,22 +80,25 @@ In the existing `@media (max-width: 36rem)` block, change only the primary navig
 }
 ```
 
+At `max-width: 27rem`, hide `.header-brand`. Separately, hide `.database-summary` through `64rem` while retaining the search field's existing `55rem` cutoff.
+
 - [ ] **Step 3: Rerun the browser regression assertion**
 
 Run the Step 1 assertion unchanged.
 
-Expected: PASS at 576, 532, 375, and 320px. `leadingGap` is within 0.5px of zero, each inter-link gap is within 0.5px of 4px, and the last navigation link does not cross the utility group's left edge.
+Expected: PASS at 624, 532, 440, 433, 432, 375, and 320px. `leadingGap` is within 0.5px of zero, each inter-link gap is within 0.5px of 4px, and the last navigation link does not cross the utility group's left edge. The wordmark is visible at 433px and hidden at 432px.
 
 - [ ] **Step 4: Visually verify the compact and adjacent layouts**
 
-Capture light-mode screenshots at 577, 576, 532, 375, and 320px and a dark-mode screenshot at 532px.
+Capture light- and dark-mode screenshots at representative widths including 624, 532, 440, 433, 432, 375, and 320px. Also inspect the 881px search boundary.
 
 Expected:
 
-- At 577px, labelled navigation remains unchanged.
-- At 576px and below, logo and navigation icons read as one left-aligned group.
+- At 625px, labelled navigation remains unchanged; at 624px, the links switch to icons.
+- Through 433px, the wordmark and navigation icons read as one left-aligned group; at 432px, the wordmark drops cleanly.
 - Theme, About, and Options remain aligned as the right group.
 - No controls overlap or clip, and the sponsorship pane remains in normal flow.
+- At 881px, the search is visible without a clipped database-summary sliver.
 
 - [ ] **Step 5: Run repository verification**
 
@@ -105,12 +109,13 @@ git diff --check
 npm run build
 ```
 
-Expected: `git diff --check` exits 0. The build reports 145/145 evidence entries with 0 errors, produces 1,757 pages, and completes successfully; the existing evidence-refetch warnings may remain.
+Expected: `git diff --check` exits 0. The build reports 145/145 evidence entries with 0 errors, produces 2,201 pages on the current `main` baseline, and completes successfully; the existing evidence-refetch warnings may remain.
 
 - [ ] **Step 6: Commit the implementation**
 
 ```bash
-git add src/styles/global.css
-git commit -m "Left-align compact header navigation"
+git add src/styles/global.css \
+  docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md \
+  docs/superpowers/plans/2026-08-13-left-aligned-compact-header.md
+git commit -m "Refine responsive header breakpoints"
 ```
-

--- a/docs/superpowers/plans/2026-08-13-mobile-header-sponsorship.md
+++ b/docs/superpowers/plans/2026-08-13-mobile-header-sponsorship.md
@@ -1,0 +1,266 @@
+# Mobile Header and Sponsorship Pane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the homepage header's 577–620 px overlap and show a compact sponsorship pane above the comparison table on narrow screens.
+
+**Architecture:** Add one intermediate header breakpoint that hides only the wordmark, extend `SponsorCTA` with an explicit `compact` rendering variant, and place that compact component outside the homepage's wide table stage. Page-scoped CSS controls mobile-only visibility and transfers the fixed-header clearance from the table stage to the pane.
+
+**Tech Stack:** Astro 5 components, scoped CSS, global CSS, the Codex in-app browser for rendered geometry checks, and the existing Astro production build.
+
+## Global Constraints
+
+- Use 39rem (624 px) for the intermediate wordmark and compact-pane breakpoint.
+- Keep the existing icon-only navigation breakpoint at 36rem (576 px).
+- Keep `SponsorCTA`'s default rankings/graph output unchanged.
+- Use the exact compact copy: `Independent graph database research.` and `Sponsorship keeps GDB-Engines running.`
+- Use the exact compact CTA label `Sponsor us` and link it to `/sponsor/`.
+- Keep the compact pane in normal document flow; it must not be sticky or fixed.
+- Do not add dependencies or redesign the Options menu, table controls, or desktop `SponsorBadge`.
+
+---
+
+### Task 1: Stage the Header Collapse
+
+**Files:**
+- Modify: `src/styles/global.css:245-285`
+- Test: rendered homepage at responsive viewports in the Codex in-app browser
+
+**Interfaces:**
+- Consumes: existing `.site-header`, `.header-brand`, `.primary-nav`, and `.site-header .right` selectors
+- Produces: a 39rem wordmark breakpoint while preserving the existing 36rem compact-navigation contract
+
+- [ ] **Step 1: Run the failing geometry check**
+
+On the running homepage at 580 px, evaluate the real rendered header:
+
+```js
+const failure = await tab.playwright.evaluate(() => {
+  const nav = document.querySelector('.primary-nav').getBoundingClientRect();
+  const utilities = document.querySelector('.site-header .right').getBoundingClientRect();
+  const brand = getComputedStyle(document.querySelector('.header-brand')).display;
+  return { overlaps: nav.right > utilities.left, brand };
+});
+if (!failure.overlaps || failure.brand === 'none') {
+  throw new Error(`Expected current 580px failure, got ${JSON.stringify(failure)}`);
+}
+```
+
+Expected: the check confirms `overlaps: true` and `brand: "block"`; current measurements show about 37 px of overlap.
+
+- [ ] **Step 2: Add the intermediate wordmark breakpoint**
+
+Insert this media query before the existing 36rem query and remove the now-redundant `.header-brand` rule from the 36rem block:
+
+```css
+@media (max-width: 39rem) {
+  .header-brand {
+    display: none;
+  }
+}
+```
+
+- [ ] **Step 3: Run the passing geometry matrix**
+
+For each width in `[625, 624, 620, 580, 577, 576, 375, 320]`, assert:
+
+```js
+const metrics = await tab.playwright.evaluate(() => {
+  const nav = document.querySelector('.primary-nav').getBoundingClientRect();
+  const utilities = document.querySelector('.site-header .right').getBoundingClientRect();
+  const brand = getComputedStyle(document.querySelector('.header-brand')).display;
+  const label = getComputedStyle(document.querySelector('.rankings-link__label')).display;
+  return { overlaps: nav.right > utilities.left, brand, label };
+});
+if (metrics.overlaps) throw new Error(`${width}px header overlaps`);
+if (width <= 624 && metrics.brand !== 'none') throw new Error(`${width}px wordmark visible`);
+if (width === 625 && metrics.brand === 'none') throw new Error('625px wordmark hidden');
+if (width >= 577 && metrics.label === 'none') throw new Error(`${width}px nav label hidden`);
+if (width <= 576 && metrics.label !== 'none') throw new Error(`${width}px nav label visible`);
+```
+
+Expected: all assertions pass.
+
+- [ ] **Step 4: Commit the header fix**
+
+```bash
+git add src/styles/global.css
+git commit -m "Fix header overlap near mobile breakpoint"
+```
+
+### Task 2: Add and Integrate the Compact Sponsorship Pane
+
+**Files:**
+- Modify: `src/components/SponsorCTA.astro:1-81`
+- Modify: `src/pages/index.astro:2-12,83-88,367-377`
+- Test: rendered homepage component and layout contract in the Codex in-app browser
+
+**Interfaces:**
+- Consumes: Astro prop `compact?: boolean`, defaulting to `false`
+- Produces: `<SponsorCTA compact />` with modifier class `sponsor-cta--compact`; `.mobile-sponsor-pane`, visible through 39rem and outside `.comparison-stage`; default `<SponsorCTA />` remains unchanged
+
+- [ ] **Step 1: Run the failing compact-pane contract**
+
+Before editing production files, run this positive assertion against the homepage:
+
+```js
+const compactCount = await tab.playwright.locator('.mobile-sponsor-pane .sponsor-cta--compact').count();
+if (compactCount !== 1) {
+  throw new Error(`Expected one compact sponsorship pane, found ${compactCount}`);
+}
+```
+
+Expected: FAIL with `Expected one compact sponsorship pane, found 0` because the feature is missing.
+
+- [ ] **Step 2: Add the `compact` prop and conditional copy**
+
+Add this frontmatter contract:
+
+```astro
+interface Props {
+  compact?: boolean;
+}
+
+const { compact = false } = Astro.props;
+```
+
+Change the `aside` class and body to:
+
+```astro
+<aside class:list={['sponsor-cta', compact && 'sponsor-cta--compact']} aria-label="Sponsor GDB-Engines">
+  {compact ? (
+    <>
+      <span class="sponsor-cta__copy">
+        <strong>Independent graph database research.</strong>{' '}
+        Sponsorship keeps GDB-Engines running.
+      </span>
+      <a href="/sponsor/">Sponsor us <span aria-hidden="true">→</span></a>
+    </>
+  ) : (
+    <>
+      <span class="sponsor-cta__copy">
+        <strong>GDB-Engines provides an independent, evidence-led view of the graph database landscape.</strong>{' '}
+        Sponsorship helps sustain the project – and connects vendors with users trying to tell their{' '}
+        <span class="sponsor-cta__pair" data-sponsor-pairs={JSON.stringify(pairings)}>GQL from their GraphQL</span>.
+      </span>
+      <a href="/sponsor/">Get in touch <span aria-hidden="true">→</span></a>
+    </>
+  )}
+</aside>
+```
+
+- [ ] **Step 3: Add compact styling without changing the default variant**
+
+Add:
+
+```css
+.sponsor-cta--compact {
+  max-width: none;
+  margin: 0;
+  padding: 0.7rem 0.75rem 0.7rem 0.85rem;
+  font-size: 0.8rem;
+}
+
+.sponsor-cta--compact a {
+  white-space: nowrap;
+}
+```
+
+Inside the existing 32rem media query, keep the compact variant on one row:
+
+```css
+.sponsor-cta--compact {
+  align-items: center;
+  flex-direction: row;
+  gap: 0.65rem;
+}
+```
+
+- [ ] **Step 4: Add the component import and homepage markup**
+
+Add:
+
+```astro
+import SponsorCTA from '../components/SponsorCTA.astro';
+```
+
+Render it between the visually hidden heading and comparison stage:
+
+```astro
+<div class="mobile-sponsor-pane">
+  <SponsorCTA compact />
+</div>
+```
+
+- [ ] **Step 5: Add page-scoped responsive layout**
+
+Add to the homepage style block:
+
+```css
+.mobile-sponsor-pane {
+  display: none;
+}
+
+@media (max-width: 39rem) {
+  .mobile-sponsor-pane {
+    display: block;
+    padding: calc(var(--header-height) + 0.75rem) 0.75rem 0.75rem;
+  }
+
+  .comparison-stage {
+    padding-top: 0;
+  }
+}
+```
+
+- [ ] **Step 6: Run the passing compact-pane contract**
+
+At 624, 580, 375, and 320 px, assert:
+
+```js
+const pane = tab.playwright.locator('.mobile-sponsor-pane');
+const compact = tab.playwright.locator('.mobile-sponsor-pane .sponsor-cta--compact');
+const link = tab.playwright.locator('.mobile-sponsor-pane a[href="/sponsor/"]');
+if (await pane.count() !== 1 || !await pane.isVisible()) throw new Error(`${width}px pane missing`);
+if (await compact.count() !== 1) throw new Error(`${width}px compact variant missing`);
+if (await link.count() !== 1) throw new Error(`${width}px sponsor link missing`);
+const layout = await tab.playwright.evaluate(() => ({
+  panePosition: getComputedStyle(document.querySelector('.mobile-sponsor-pane')).position,
+  paneLeft: document.querySelector('.mobile-sponsor-pane .sponsor-cta').getBoundingClientRect().left,
+  paneRight: document.querySelector('.mobile-sponsor-pane .sponsor-cta').getBoundingClientRect().right,
+  viewportWidth: innerWidth,
+  paneBottom: document.querySelector('.mobile-sponsor-pane').getBoundingClientRect().bottom,
+  tableTop: document.querySelector('.comparison-stage').getBoundingClientRect().top
+}));
+if (layout.panePosition === 'fixed' || layout.panePosition === 'sticky') throw new Error('Pane is persistent');
+if (layout.paneLeft < 0 || layout.paneRight > layout.viewportWidth) throw new Error('Pane overflows viewport');
+if (layout.tableTop < layout.paneBottom) throw new Error('Pane overlaps table');
+```
+
+At 625 px, assert `.mobile-sponsor-pane` is hidden and `.comparison-stage` starts at `var(--header-height)`.
+
+- [ ] **Step 7: Verify existing default sponsor panels are unchanged**
+
+Open `/rankings/` and `/graph/query-languages/` and assert each visible `.sponsor-cta` lacks the `sponsor-cta--compact` modifier, still contains the `Get in touch` link, and retains the full evidence-led sponsorship copy.
+
+- [ ] **Step 8: Visually inspect light and dark modes**
+
+Capture viewport screenshots at 580 and 375 px in both themes. Confirm the header groups do not collide, the pane is inset and legible, the CTA remains within the pane at 320 px, and the table header starts below the pane before becoming sticky below the fixed header during scrolling.
+
+- [ ] **Step 9: Run full verification**
+
+Run:
+
+```bash
+npm run build
+git diff --check
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 10: Commit the completed feature**
+
+```bash
+git add src/components/SponsorCTA.astro src/pages/index.astro docs/superpowers/plans/2026-08-13-mobile-header-sponsorship.md
+git commit -m "Show compact sponsorship pane on mobile"
+```

--- a/docs/superpowers/plans/2026-08-13-mobile-header-sponsorship.md
+++ b/docs/superpowers/plans/2026-08-13-mobile-header-sponsorship.md
@@ -1,5 +1,7 @@
 # Mobile Header and Sponsorship Pane Implementation Plan
 
+> **Superseded responsive details:** The sponsorship work in this plan was implemented, but its header breakpoints were subsequently refined. The approved final header behavior is documented in `2026-08-13-left-aligned-compact-header.md`: navigation becomes icon-only at 39rem, while the wordmark remains visible through 433px and hides at 432px.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Remove the homepage header's 577–620 px overlap and show a compact sponsorship pane above the comparison table on narrow screens.

--- a/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
@@ -1,0 +1,87 @@
+# Mobile Header and Sponsorship Pane Design
+
+Date: 2026-08-13
+Status: Approved in conversation
+
+## Problem
+
+The homepage header has a narrow responsive failure band. On the comparison page at a 580 px viewport, the primary navigation extends to approximately x=456.5 while the utility controls begin at approximately x=419.2, so the groups overlap by about 37 px. The full wordmark and labelled navigation remain enabled until the existing compact breakpoint at 36rem (576 px). At 576 px the compact icon layout activates and the overlap disappears, which is why smaller phones such as the iPhone 13 mini look acceptable.
+
+The homepage sponsorship disclosure is also unavailable on narrow screens. `SponsorBadge` is deliberately hidden below 72rem, leaving mobile visitors without the sponsorship information that appears elsewhere in the site.
+
+## Goals
+
+- Remove header overlap throughout the 577–620 px transition range.
+- Preserve the existing compact phone layout at and below 36rem.
+- Keep labelled primary navigation visible for as long as it fits.
+- Give narrow-screen homepage visitors a visible sponsorship message without adding another header control.
+- Reuse the visual language of the existing sponsorship panels on rankings and graph pages.
+- Avoid obstructing the comparison table or consuming persistent vertical space.
+
+## Non-goals
+
+- Redesigning the primary navigation, Options menu, or table controls.
+- Changing the desktop `SponsorBadge` disclosure or its 72rem visibility threshold.
+- Changing sponsorship placement on rankings, graph, or comparison-detail pages.
+- Changing the comparison table's horizontal scrolling or sticky-column behavior.
+
+## Responsive Header Design
+
+Use a staged collapse rather than moving the complete compact layout to a larger breakpoint.
+
+- Between 36rem and 39rem (577–624 px), hide only `.header-brand`, the `GDB-Engines` wordmark. Keep the logo, labelled Rankings/Graph/Compare links, and existing right-side controls.
+- At and below 36rem (576 px), retain the current compact behavior: navigation labels are hidden, the home link is logo-only, and the navigation distributes the three icons within the available left-side space.
+- Leave the search-field behavior and the special 22rem About-button treatment unchanged.
+
+The 39rem threshold provides a small safety margin: the full layout has clean separation again at approximately 620 px, and at 625 px the uncollapsed layout fits. Hiding only the wordmark in the intermediate range removes roughly 99 px without sacrificing navigation labels.
+
+## Compact Sponsorship Pane
+
+Add a compact variant of the existing `SponsorCTA` component so it shares the established gradient, border, typography, theme colors, and call-to-action styling without duplicating those rules.
+
+The compact content is:
+
+> **Independent graph database research.**  
+> Sponsorship keeps GDB-Engines running.  
+> **Sponsor us →**
+
+The call to action links to `/sponsor/`.
+
+On the homepage:
+
+- Render the compact pane after the fixed site header and before `.comparison-stage`.
+- Show it only at and below 39rem.
+- Keep it in normal document flow; it scrolls away with the page and is never sticky or fixed.
+- Inset it from the viewport edges using the same narrow-screen page spacing used elsewhere.
+- When the pane is visible, it owns the space needed to clear the fixed header and the comparison stage no longer adds a second header-height offset. Above 39rem, the pane is hidden and the comparison stage retains its current header-height padding.
+- Keep the pane outside the table's `width: max-content` stage so it is sized to the viewport rather than to the wide comparison table.
+
+`SponsorCTA`'s current default output remains unchanged for existing rankings and graph consumers. The compact variant does not use the rotating phrase script because its shorter copy is fixed.
+
+## Accessibility and Interaction
+
+- Keep the sponsorship content in an `aside` labelled `Sponsor GDB-Engines`.
+- Use a normal link for the call to action; no disclosure or JavaScript interaction is required.
+- Preserve visible keyboard focus styling and the existing contrast-aware theme variables.
+- Do not display both the compact pane and desktop `SponsorBadge` at the same viewport width.
+- The header's existing link names and `aria-current` behavior remain unchanged.
+
+## Verification
+
+Use a browser geometry assertion before the CSS change to demonstrate the current 580 px overlap, then rerun it after the change. On the homepage, verify that the primary navigation's right edge does not pass the utility group's left edge at 620, 580, 577, 576, 375, 320 px.
+
+Also verify:
+
+- The wordmark is hidden at 620, 580, and 577 px, and visible at 625 px.
+- Navigation labels remain visible at 577–624 px and switch to icons at 576 px.
+- The compact sponsorship pane is visible at 624 px and below, hidden at 625 px and above, and links to `/sponsor/`.
+- The existing desktop sponsor badge remains visible at its current 72rem threshold.
+- The pane fits at 320 px without horizontal overflow.
+- Light and dark mode screenshots at 580 and 375 px show no collision, clipping, or table-header obstruction.
+- The production build completes successfully.
+
+## Alternatives Considered
+
+- Moving the entire icon-only layout to 39rem would fix the collision but remove useful labels earlier than necessary.
+- Adding sponsorship to the Options menu would save space but make it less discoverable and mix project support with table configuration.
+- A sticky or fixed sponsorship banner would be more prominent but would obscure too much of the comparison table on a small screen.

--- a/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
@@ -5,16 +5,17 @@ Status: Approved in conversation
 
 ## Problem
 
-The homepage header has a narrow responsive failure band. On the comparison page at a 580 px viewport, the primary navigation extends to approximately x=456.5 while the utility controls begin at approximately x=419.2, so the groups overlap by about 37 px. The full wordmark and labelled navigation remain enabled until the existing compact breakpoint at 36rem (576 px). At 576 px the compact icon layout activates and the overlap disappears, which is why smaller phones such as the iPhone 13 mini look acceptable.
+The homepage header has narrow responsive failure bands. The original layout overlaps around 580 px, while hiding the wordmark throughout the first compact treatment makes the header look unnecessarily sparse at widths such as 440 and 532 px. At the desktop-search boundary, the database summary can also collapse to a one-character sliver beside the newly visible search field.
 
 The homepage sponsorship disclosure is also unavailable on narrow screens. `SponsorBadge` is deliberately hidden below 72rem, leaving mobile visitors without the sponsorship information that appears elsewhere in the site.
 
 ## Goals
 
-- Remove header overlap throughout the 577–620 px transition range.
-- Preserve the compact phone layout's icon-only controls at and below 36rem.
+- Remove header overlap throughout the responsive range.
+- Switch to compact icon-only navigation at and below 39rem.
 - Keep compact navigation visually grouped with the home logo instead of distributing it across the header.
-- Keep labelled primary navigation visible for as long as it fits.
+- Keep the wordmark visible through 433 px, including at 440 px, and hide it only when the complete header no longer fits.
+- Prevent the database summary from appearing as clipped text beside the search field.
 - Give narrow-screen homepage visitors a visible sponsorship message without adding another header control.
 - Reuse the visual language of the existing sponsorship panels on rankings and graph pages.
 - Avoid obstructing the comparison table or consuming persistent vertical space.
@@ -28,14 +29,15 @@ The homepage sponsorship disclosure is also unavailable on narrow screens. `Spon
 
 ## Responsive Header Design
 
-Use a staged collapse rather than moving the complete compact layout to a larger breakpoint.
+Use a staged, brand-first collapse:
 
-- Between 36rem and 39rem (577–624 px), hide only `.header-brand`, the `GDB-Engines` wordmark. Keep the logo, labelled Rankings/Graph/Compare links, and existing right-side controls.
-- At and below 36rem (576 px), use a compact two-group layout. The left group contains the logo followed immediately by the Rankings, Graph, and Compare icon buttons, aligned from the left with the existing compact gap. The right group keeps theme, About, and Options pinned to the right edge. Navigation labels remain hidden and the home link remains logo-only.
+- Above 39rem (624 px), show the wordmark and labelled Rankings/Graph/Compare links.
+- At and below 39rem, use a compact two-group layout. The left group contains the logo, wordmark, and the three icon-only navigation buttons, aligned from the left with a 0.25rem gap between navigation links. The right group keeps theme, About, and Options pinned to the right edge.
+- At and below 27rem (432 px), hide `.header-brand`. The left group then contains only the logo and three navigation icons, leaving the required gap before the utility group.
 - Do not use `space-evenly` for the compact primary navigation. The primary navigation may retain flexible width to preserve separation from the right-side utilities, but its contents use start alignment so extra space remains between the two groups rather than between individual navigation buttons.
-- Leave the search-field behavior and the special 22rem About-button treatment unchanged.
+- Hide `.database-summary` at and below 64rem so it cannot collapse into a sliver when the search field returns. Keep the existing search-field cutoff at 55rem and the special 22rem About-button treatment.
 
-The 39rem threshold provides a small safety margin: the full layout has clean separation again at approximately 620 px, and at 625 px the uncollapsed layout fits. Hiding only the wordmark in the intermediate range removes roughly 99 px without sacrificing navigation labels.
+The 39rem threshold is the last width before the labelled layout fits; the full layout remains intact at 625 px. The 27rem wordmark threshold follows measured fit rather than a device class: at 440 px the header has approximately 16 px between navigation and utilities, at 433 px it retains the configured 8 px separation, and at 432 px the wordmark is removed.
 
 ## Compact Sponsorship Pane
 
@@ -43,8 +45,8 @@ Add a compact variant of the existing `SponsorCTA` component so it shares the es
 
 The compact content is:
 
-> **Independent graph database research.**  
-> Sponsorship keeps GDB-Engines running.  
+> **Independent graph database research.**<br>
+> Sponsorship keeps GDB-Engines running.<br>
 > **Sponsor us →**
 
 The call to action links to `/sponsor/`.
@@ -70,23 +72,25 @@ On the homepage:
 
 ## Verification
 
-Use a browser geometry assertion before the CSS change to demonstrate the current 580 px overlap, then rerun it after the change. On the homepage, verify that the primary navigation's right edge does not pass the utility group's left edge at 620, 580, 577, 576, 375, 320 px.
+Use browser geometry assertions to verify that the primary navigation's right edge does not pass the utility group's left edge at 625, 624, 532, 440, 433, 432, 375, and 320 px.
 
 Also verify:
 
-- The wordmark is hidden at 620, 580, and 577 px, and visible at 625 px.
-- Navigation labels remain visible at 577–624 px and switch to icons at 576 px.
-- At 576, 532, 375, and 320 px, the logo and three navigation icons form one left-aligned cluster while theme, About, and Options remain a separate right-aligned cluster.
+- The wordmark is visible from 625 through 433 px and hidden at 432 px and below.
+- Navigation labels are visible at 625 px and switch to icons at 624 px.
+- At 624, 532, 440, 433, 432, 375, and 320 px, the brand and navigation form one left-aligned cluster while theme, About, and Options remain a separate right-aligned cluster.
 - The gaps between compact navigation icons stay equal to the configured navigation gap rather than expanding with viewport width.
+- At 881 and 1024 px the search field is visible while the database summary is hidden; at 1025 px the summary can return without overlap.
 - The compact sponsorship pane is visible at 624 px and below, hidden at 625 px and above, and links to `/sponsor/`.
 - The existing desktop sponsor badge remains visible at its current 72rem threshold.
 - The pane fits at 320 px without horizontal overflow.
-- Light and dark mode screenshots at 580 and 375 px show no collision, clipping, or table-header obstruction.
+- Light and dark mode screenshots at representative compact widths show no collision, clipping, or table-header obstruction.
 - The production build completes successfully.
 
 ## Alternatives Considered
 
-- Moving the entire icon-only layout to 39rem would fix the collision but remove useful labels earlier than necessary.
+- Keeping labelled navigation between 36rem and 39rem preserves text but produces an awkward intermediate hierarchy; switching the links to icons at 39rem keeps the wordmark and makes the compact header read as one coherent group.
+- Hiding the wordmark at 39rem creates excessive empty space at common phone widths; the measured 27rem cutoff preserves the site identity until it is actually needed for fit.
 - Distributing compact navigation with `space-evenly` uses the available width but makes related links look like unrelated controls; start alignment preserves their grouping and leaves flexible space between navigation and utilities.
 - Adding sponsorship to the Options menu would save space but make it less discoverable and mix project support with table configuration.
 - A sticky or fixed sponsorship banner would be more prominent but would obscure too much of the comparison table on a small screen.

--- a/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
+++ b/docs/superpowers/specs/2026-08-13-mobile-header-sponsorship-design.md
@@ -12,7 +12,8 @@ The homepage sponsorship disclosure is also unavailable on narrow screens. `Spon
 ## Goals
 
 - Remove header overlap throughout the 577–620 px transition range.
-- Preserve the existing compact phone layout at and below 36rem.
+- Preserve the compact phone layout's icon-only controls at and below 36rem.
+- Keep compact navigation visually grouped with the home logo instead of distributing it across the header.
 - Keep labelled primary navigation visible for as long as it fits.
 - Give narrow-screen homepage visitors a visible sponsorship message without adding another header control.
 - Reuse the visual language of the existing sponsorship panels on rankings and graph pages.
@@ -30,7 +31,8 @@ The homepage sponsorship disclosure is also unavailable on narrow screens. `Spon
 Use a staged collapse rather than moving the complete compact layout to a larger breakpoint.
 
 - Between 36rem and 39rem (577–624 px), hide only `.header-brand`, the `GDB-Engines` wordmark. Keep the logo, labelled Rankings/Graph/Compare links, and existing right-side controls.
-- At and below 36rem (576 px), retain the current compact behavior: navigation labels are hidden, the home link is logo-only, and the navigation distributes the three icons within the available left-side space.
+- At and below 36rem (576 px), use a compact two-group layout. The left group contains the logo followed immediately by the Rankings, Graph, and Compare icon buttons, aligned from the left with the existing compact gap. The right group keeps theme, About, and Options pinned to the right edge. Navigation labels remain hidden and the home link remains logo-only.
+- Do not use `space-evenly` for the compact primary navigation. The primary navigation may retain flexible width to preserve separation from the right-side utilities, but its contents use start alignment so extra space remains between the two groups rather than between individual navigation buttons.
 - Leave the search-field behavior and the special 22rem About-button treatment unchanged.
 
 The 39rem threshold provides a small safety margin: the full layout has clean separation again at approximately 620 px, and at 625 px the uncollapsed layout fits. Hiding only the wordmark in the intermediate range removes roughly 99 px without sacrificing navigation labels.
@@ -74,6 +76,8 @@ Also verify:
 
 - The wordmark is hidden at 620, 580, and 577 px, and visible at 625 px.
 - Navigation labels remain visible at 577–624 px and switch to icons at 576 px.
+- At 576, 532, 375, and 320 px, the logo and three navigation icons form one left-aligned cluster while theme, About, and Options remain a separate right-aligned cluster.
+- The gaps between compact navigation icons stay equal to the configured navigation gap rather than expanding with viewport width.
 - The compact sponsorship pane is visible at 624 px and below, hidden at 625 px and above, and links to `/sponsor/`.
 - The existing desktop sponsor badge remains visible at its current 72rem threshold.
 - The pane fits at 320 px without horizontal overflow.
@@ -83,5 +87,6 @@ Also verify:
 ## Alternatives Considered
 
 - Moving the entire icon-only layout to 39rem would fix the collision but remove useful labels earlier than necessary.
+- Distributing compact navigation with `space-evenly` uses the available width but makes related links look like unrelated controls; start alignment preserves their grouping and leaves flexible space between navigation and utilities.
 - Adding sponsorship to the Options menu would save space but make it less discoverable and mix project support with table configuration.
 - A sticky or fixed sponsorship banner would be more prominent but would obscure too much of the comparison table on a small screen.

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -43,7 +43,7 @@ const onCompare = path.startsWith('/compare');
         </svg>
         <span class="rankings-link__label">Rankings</span>
       </a>
-      <a href="/graph/query-languages/" class:list={['rankings-link', 'graph-link', onGraph && 'is-active']} aria-current={onGraph ? 'page' : undefined}>
+      <a href="/graph/query-languages/" class:list={['rankings-link', 'graph-link', onGraph && 'is-active']} aria-current={onGraph ? 'page' : undefined} aria-label="Graph database query language explorer">
         <svg class="rankings-link__icon graph-link__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
           <path d="M4 4.5 8 7m0 0 4-3M8 7l1.5 4.5"/>
           <circle cx="3" cy="3.75" r="1.75"/>

--- a/src/components/SponsorCTA.astro
+++ b/src/components/SponsorCTA.astro
@@ -8,19 +8,37 @@ const pairings = [
   'graph databases from their graph query engines',
   'SPARQL from their SQL/PGQ',
 ];
+
+interface Props {
+  compact?: boolean;
+}
+
+const { compact = false } = Astro.props;
 ---
-<aside class="sponsor-cta" aria-label="Sponsor GDB-Engines">
-  <span class="sponsor-cta__copy">
-    <strong>GDB-Engines provides an independent, evidence-led view of the graph
-    database landscape.</strong>
-    Sponsorship helps sustain the project – and connects vendors with users
-    trying to tell their
-    <span
-      class="sponsor-cta__pair"
-      data-sponsor-pairs={JSON.stringify(pairings)}
-    >GQL from their GraphQL</span>.
-  </span>
-  <a href="/sponsor/">Get in touch <span aria-hidden="true">→</span></a>
+<aside class:list={['sponsor-cta', compact && 'sponsor-cta--compact']} aria-label="Sponsor GDB-Engines">
+  {compact ? (
+    <>
+      <span class="sponsor-cta__copy">
+        <strong>Independent graph database research.</strong>{' '}
+        Sponsorship keeps GDB-Engines running.
+      </span>
+      <a href="/sponsor/">Sponsor us <span aria-hidden="true">→</span></a>
+    </>
+  ) : (
+    <>
+      <span class="sponsor-cta__copy">
+        <strong>GDB-Engines provides an independent, evidence-led view of the graph
+        database landscape.</strong>
+        Sponsorship helps sustain the project – and connects vendors with users
+        trying to tell their
+        <span
+          class="sponsor-cta__pair"
+          data-sponsor-pairs={JSON.stringify(pairings)}
+        >GQL from their GraphQL</span>.
+      </span>
+      <a href="/sponsor/">Get in touch <span aria-hidden="true">→</span></a>
+    </>
+  )}
 </aside>
 
 <script is:inline>
@@ -57,6 +75,13 @@ const pairings = [
     color: var(--color-text);
   }
 
+  .sponsor-cta--compact {
+    max-width: none;
+    margin: 0;
+    padding: 0.7rem 0.75rem 0.7rem 0.85rem;
+    font-size: 0.8rem;
+  }
+
   .sponsor-cta a {
     flex: 0 0 auto;
     padding: 0.42rem 0.7rem;
@@ -71,11 +96,20 @@ const pairings = [
     filter: brightness(1.06);
   }
 
+  .sponsor-cta--compact a {
+    white-space: nowrap;
+  }
+
   @media (max-width: 32rem) {
     .sponsor-cta {
       align-items: flex-start;
       flex-direction: column;
       gap: 0.65rem;
+    }
+
+    .sponsor-cta--compact {
+      align-items: center;
+      flex-direction: row;
     }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import SiteHeader from '../components/SiteHeader.astro';
 import DatabaseLogo from '../components/DatabaseLogo.astro';
+import SponsorCTA from '../components/SponsorCTA.astro';
 import '../styles/global.css';
 import { getCollection } from 'astro:content';
 import { featureGroups, featureDisplayNames, columnTooltips } from '../data/feature-metadata';
@@ -83,6 +84,10 @@ const datasetJsonLd = JSON.stringify({
   <SiteHeader comparisonControls sponsorBadge />
 
   <h1 class="sr-only">Graph Database Comparison — {databases.length}+ Engines</h1>
+
+  <div class="mobile-sponsor-pane">
+    <SponsorCTA compact />
+  </div>
 
   <div class="comparison-stage">
     <table>
@@ -365,6 +370,10 @@ const datasetJsonLd = JSON.stringify({
 </Layout>
 
 <style>
+  .mobile-sponsor-pane {
+    display: none;
+  }
+
   .comparison-stage {
     width: max-content;
     min-width: 100%;
@@ -373,5 +382,16 @@ const datasetJsonLd = JSON.stringify({
 
   .comparison-stage table {
     margin-top: 0;
+  }
+
+  @media (max-width: 39rem) {
+    .mobile-sponsor-pane {
+      display: block;
+      padding: calc(var(--header-height) + 0.75rem) 0.75rem 0.75rem;
+    }
+
+    .comparison-stage {
+      padding-top: 0;
+    }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -260,6 +260,12 @@ a {
     }
   }
 
+  @media (max-width: 39rem) {
+    .header-brand {
+      display: none;
+    }
+  }
+
   @media (max-width: 36rem) {
     div.left {
       gap: 0.25rem;
@@ -276,10 +282,6 @@ a {
         flex: 1 1 auto;
         justify-content: space-evenly;
         gap: 0.25rem;
-      }
-
-      .header-brand {
-        display: none;
       }
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -280,7 +280,7 @@ a {
 
       .primary-nav {
         flex: 1 1 auto;
-        justify-content: space-evenly;
+        justify-content: flex-start;
         gap: 0.25rem;
       }
     }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -246,6 +246,10 @@ a {
     .database-summary {
       display: none;
     }
+
+    div.right .search-container {
+      display: none;
+    }
   }
 
   @media (max-width: 45rem) {
@@ -253,10 +257,6 @@ a {
 
     div.right {
       gap: 0.375rem;
-
-      .search-container {
-        display: none;
-      }
     }
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -242,11 +242,13 @@ a {
     align-items: center;
   }
 
-  @media (max-width: 55rem) {
+  @media (max-width: 64rem) {
     .database-summary {
       display: none;
     }
+  }
 
+  @media (max-width: 55rem) {
     div.right .search-container {
       display: none;
     }
@@ -261,18 +263,8 @@ a {
   }
 
   @media (max-width: 39rem) {
-    .header-brand {
-      display: none;
-    }
-  }
-
-  @media (max-width: 36rem) {
     div.left {
       gap: 0.25rem;
-
-      .database-summary {
-        display: none;
-      }
 
       .header-home {
         margin-right: 0;
@@ -283,6 +275,12 @@ a {
         justify-content: flex-start;
         gap: 0.25rem;
       }
+    }
+  }
+
+  @media (max-width: 27rem) {
+    .header-brand {
+      display: none;
     }
   }
 
@@ -545,7 +543,7 @@ th.rank-col { padding-left: 0.5rem; padding-right: 0.5rem; }
 .rankings-link__icon { flex-shrink: 0; }
 .graph-link { gap: 0.35rem; }
 .graph-link__icon { flex-shrink: 0; }
-@media (max-width: 36rem) {
+@media (max-width: 39rem) {
   .rankings-link__label { display: none; }
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1070,6 +1070,7 @@ tr.row-deprecated:hover td {
 
 /* Hamburger menu */
 .menu-wrapper {
+  display: flex;
   position: relative;
 }
 .menu-btn {


### PR DESCRIPTION
## Summary

- add a compact sponsorship pane above the mobile rankings table
- keep the GDB-Engines wordmark until 432px while switching primary navigation to a left-aligned icon group at 624px
- prevent search, summary, and utility controls from overlapping at responsive boundaries
- preserve accessible names for every icon-only navigation link

## Verification

- browser geometry checks at 625, 624, 532, 440, 433, 432, 375, and 320px
- light and dark visual checks across representative widths
- search/summary boundary checks at 881, 1024, and 1025px
- `git diff --check origin/main...HEAD`
- `npm run build` — 145/145 evidence entries, 0 errors, 2,201 pages