### PR TITLE
Fix Garphield graph document labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
+    "test": "node --test",
     "favicons": "node scripts/extract-favicons.mjs",
     "graphs": "node scripts/generate-graphs.mjs",
     "check-evidence": "node scripts/check-evidence.mjs",

--- a/public/graphs/databases-languages.gfd
+++ b/public/graphs/databases-languages.gfd
@@ -2597,6 +2597,60 @@
         },
         "resultType": "cat"
       }
-    ]
+    ],
+    "current": {
+      "version": 1,
+      "state": {
+        "v": 1,
+        "dataset": {
+          "kind": "file",
+          "name": "Databases × query languages"
+        },
+        "layout": "force",
+        "labels": true,
+        "tapered": false,
+        "edgeGradient": false,
+        "theme": "light",
+        "bindings": [
+          {
+            "channel": "size",
+            "source": {
+              "kind": "algorithm",
+              "id": "degree"
+            },
+            "resultType": "num"
+          },
+          {
+            "channel": "image",
+            "source": {
+              "kind": "field",
+              "id": "image"
+            },
+            "resultType": "cat"
+          },
+          {
+            "channel": "color",
+            "source": {
+              "kind": "field",
+              "id": "kind"
+            },
+            "resultType": "cat"
+          }
+        ],
+        "filterStack": [],
+        "selection": {
+          "primary": null,
+          "set": [],
+          "target": null
+        },
+        "camera": null,
+        "panel": {
+          "bottomOpen": false,
+          "bottom": 240,
+          "floating": false
+        }
+      },
+      "playerIndex": null
+    }
   }
 }

--- a/public/graphs/databases-similarity.gfd
+++ b/public/graphs/databases-similarity.gfd
@@ -3406,6 +3406,69 @@
         },
         "resultType": "num"
       }
-    ]
+    ],
+    "current": {
+      "version": 1,
+      "state": {
+        "v": 1,
+        "dataset": {
+          "kind": "file",
+          "name": "Database similarity"
+        },
+        "layout": "force",
+        "labels": true,
+        "tapered": false,
+        "edgeGradient": false,
+        "theme": "light",
+        "bindings": [
+          {
+            "channel": "size",
+            "source": {
+              "kind": "algorithm",
+              "id": "degree"
+            },
+            "resultType": "num"
+          },
+          {
+            "channel": "image",
+            "source": {
+              "kind": "field",
+              "id": "image"
+            },
+            "resultType": "cat"
+          },
+          {
+            "channel": "color",
+            "source": {
+              "kind": "field",
+              "id": "type"
+            },
+            "resultType": "cat"
+          },
+          {
+            "channel": "edgeWidth",
+            "source": {
+              "kind": "field",
+              "id": "similarity",
+              "target": "edge"
+            },
+            "resultType": "num"
+          }
+        ],
+        "filterStack": [],
+        "selection": {
+          "primary": null,
+          "set": [],
+          "target": null
+        },
+        "camera": null,
+        "panel": {
+          "bottomOpen": false,
+          "bottom": 240,
+          "floating": false
+        }
+      },
+      "playerIndex": null
+    }
   }
 }

--- a/scripts/generate-graphs.mjs
+++ b/scripts/generate-graphs.mjs
@@ -33,6 +33,21 @@ const databases = await Promise.all(
 );
 
 function document(name, nodes, links, config) {
+  const current = {
+    v: 1,
+    dataset: { kind: "file", name },
+    layout: config.layout,
+    labels: true,
+    tapered: false,
+    edgeGradient: false,
+    theme: "light",
+    bindings: config.bindings,
+    filterStack: config.filterStack ?? [],
+    selection: { primary: null, set: [], target: null },
+    camera: null,
+    panel: { bottomOpen: false, bottom: 240, floating: false },
+  };
+
   return {
     info: { version: 1, name },
     datasets: [
@@ -47,7 +62,10 @@ function document(name, nodes, links, config) {
         },
       },
     ],
-    config,
+    config: {
+      ...config,
+      current: { version: 1, state: current, playerIndex: null },
+    },
   };
 }
 

--- a/scripts/generate-graphs.test.mjs
+++ b/scripts/generate-graphs.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const generatedDocuments = [
+  ["public/graphs/databases-languages.gfd", "Databases × query languages"],
+  ["public/graphs/databases-similarity.gfd", "Database similarity"],
+];
+
+test("generated graph documents identify themselves in Garphield", async () => {
+  const committed = new Map(
+    await Promise.all(
+      generatedDocuments.map(async ([path]) => [
+        path,
+        await readFile(path, "utf8"),
+      ]),
+    ),
+  );
+  execFileSync(process.execPath, ["scripts/generate-graphs.mjs"]);
+
+  for (const [path, name] of generatedDocuments) {
+    const generated = await readFile(path, "utf8");
+    assert.equal(generated, committed.get(path), `${path} is stale`);
+
+    const document = JSON.parse(generated);
+
+    assert.deepEqual(document.config.current?.state.dataset, {
+      kind: "file",
+      name,
+    });
+  }
+});

--- a/src/lib/garphield-document.mjs
+++ b/src/lib/garphield-document.mjs
@@ -1,0 +1,8 @@
+/** Clone a generated graph document and align its saved view with the host. */
+export function prepareGarphieldDocument(source, theme) {
+  const document = structuredClone(source);
+  if (document.config?.current?.state) {
+    document.config.current.state.theme = theme;
+  }
+  return document;
+}

--- a/src/lib/garphield-document.test.mjs
+++ b/src/lib/garphield-document.test.mjs
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+test("prepares a themed clone without mutating the generated document", async () => {
+  const { prepareGarphieldDocument } = await import(
+    "./garphield-document.mjs"
+  );
+  const source = {
+    config: {
+      current: {
+        state: { theme: "light" },
+      },
+    },
+  };
+
+  const prepared = prepareGarphieldDocument(source, "dark");
+
+  assert.equal(prepared.config.current.state.theme, "dark");
+  assert.equal(source.config.current.state.theme, "light");
+  assert.notEqual(prepared, source);
+});
+
+test("preserves a legacy document without current view state", async () => {
+  const { prepareGarphieldDocument } = await import(
+    "./garphield-document.mjs"
+  );
+  const source = { config: { version: 1 } };
+
+  const prepared = prepareGarphieldDocument(source, "dark");
+
+  assert.deepEqual(prepared, source);
+  assert.notEqual(prepared, source);
+});

--- a/src/pages/graph.astro
+++ b/src/pages/graph.astro
@@ -373,6 +373,7 @@ function timelineTypeClass(type: string): string {
 
   <script>
     import { createGarphield } from 'garphield';
+    import { prepareGarphieldDocument } from '../lib/garphield-document.mjs';
 
     const page = document.querySelector('.graph-page');
     const graphStage = document.querySelector('.graph-stage');
@@ -912,7 +913,7 @@ function timelineTypeClass(type: string): string {
       }
 
       async function renderDocument(source, version, graphHidden, context) {
-        const document = structuredClone(source);
+        const document = prepareGarphieldDocument(source, effectiveTheme());
         const graph = document.datasets[0].graph;
 
         if (!context.loaded) {


### PR DESCRIPTION
Summary:
- emit a complete Garphield current state with each generated graph own dataset name
- align the saved document theme with the host before loading it
- retain compatibility with older generated documents that have no saved current state
- test dataset labels, generated artifact freshness, theme handling, and legacy documents

Verification:
- npm test: 3 tests passed
- npm run build: 2,186 pages built successfully