### PR TITLE
Add GraphRAG and agent-memory ranking boards

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,6 +3,7 @@ import { glob } from 'astro/loaders';
 import { PROTOCOLS } from './lib/protocols';
 
 const featureScore = z.number().min(0).max(1);
+const aiRole = z.enum(['agent-memory', 'graphrag']);
 
 const databases = defineCollection({
   loader: glob({ pattern: '**/*.toml', base: './src/content/databases' }),
@@ -11,6 +12,9 @@ const databases = defineCollection({
     vendor: z.string().optional(),
     slug: z.string().min(1).regex(/^[a-z0-9-]+$/),
     description: z.string(),
+    // Curated AI role classification. This is intentionally separate from the general
+    // description: generic AI, vector, or graph language is not enough for inclusion.
+    ai_roles: z.array(aiRole).default([]),
     url: z.string().url().optional(),
     github_url: z.string().url().optional(),
     license: z.string().optional(),

--- a/src/content/databases/arangodb.toml
+++ b/src/content/databases/arangodb.toml
@@ -2,6 +2,7 @@ name = "ArangoDB"
 vendor = "ArangoDB Inc"
 slug = "arangodb"
 description = "A multi-model database supporting graphs, key-value pairs, and documents in a unified JSON-based data model. Offers both an in-memory storage engine and a RocksDB-based engine for larger datasets."
+ai_roles = ["graphrag"]
 url = "https://www.arangodb.com/"
 github_url = "https://github.com/arangodb/arangodb"
 license = "BUSL-1.1"

--- a/src/content/databases/arcadedb.toml
+++ b/src/content/databases/arcadedb.toml
@@ -2,6 +2,7 @@ name = "ArcadeDB"
 vendor = "ArcadeDB"
 slug = "arcadedb"
 description = "A multi-model database inspired by OrientDB, supporting graphs, documents, key-value, time-series, and search. Uses RAFT-based replication for high availability."
+ai_roles = ["agent-memory", "graphrag"]
 url = "https://arcadedb.com/"
 github_url = "https://github.com/ArcadeData/arcadedb"
 license = "Apache-2.0"

--- a/src/content/databases/bigquery-graph.toml
+++ b/src/content/databases/bigquery-graph.toml
@@ -2,6 +2,7 @@ name = "Google Cloud BigQuery Graph"
 vendor = "Google"
 slug = "bigquery-graph"
 description = "A graph layer within Google Cloud BigQuery that runs property graph queries over warehouse tables using GQL, without a separate graph store. Property graphs are defined as views over existing tables and queried at analytical scale."
+ai_roles = ["graphrag"]
 url = "https://cloud.google.com/bigquery/docs/reference/standard-sql/graph-intro"
 license = "Proprietary"
 implementation_language = "C++"

--- a/src/content/databases/cosmos-db.toml
+++ b/src/content/databases/cosmos-db.toml
@@ -2,6 +2,7 @@ name = "Cosmos DB"
 vendor = "Microsoft"
 slug = "cosmos-db"
 description = "A globally distributed multi-model database service on Microsoft Azure with property graph support through the Apache Gremlin API. Offers multi-region replication and multiple consistency models."
+ai_roles = ["graphrag"]
 url = "https://azure.microsoft.com/en-us/products/cosmos-db"
 license = "Proprietary"
 implementation_language = "C++"

--- a/src/content/databases/data-graphs.toml
+++ b/src/content/databases/data-graphs.toml
@@ -2,6 +2,7 @@ name = "Data Graphs"
 vendor = "Data Language"
 slug = "data-graphs"
 description = "A proprietary graph database built in Rust with a hybrid model combining labeled property graph and RDF/OWL ontology semantics, queried with openCypher and ISO GQL. Sits within an agentic AI data platform offering governance, GraphRAG, and MCP-native access; deployable as SaaS, on-premises, or on-device."
+ai_roles = ["graphrag"]
 url = "https://datagraphs.com/"
 license = "Proprietary"
 type = "Multiple"

--- a/src/content/databases/fabric-graph.toml
+++ b/src/content/databases/fabric-graph.toml
@@ -2,6 +2,7 @@ name = "Microsoft Fabric Graph"
 vendor = "Microsoft"
 slug = "fabric-graph"
 description = "A graph engine within Microsoft Fabric that builds a read-optimized property graph from lakehouse tables stored in OneLake, queried with GQL or a visual builder. Reads directly from Delta Lake tables without a separate ETL pipeline."
+ai_roles = ["graphrag"]
 url = "https://learn.microsoft.com/en-us/fabric/graph/how-graph-works"
 license = "Proprietary"
 type = "Property Graph"

--- a/src/content/databases/helixdb.toml
+++ b/src/content/databases/helixdb.toml
@@ -2,6 +2,7 @@ name = "HelixDB"
 vendor = "HelixDB"
 slug = "helixdb"
 description = "An open-source graph-vector database combining graph traversals with vector and keyword search, targeting AI and RAG applications."
+ai_roles = ["agent-memory", "graphrag"]
 url = "https://www.helix-db.com/"
 github_url = "https://github.com/HelixDB/helix-db"
 license = "Apache-2.0"

--- a/src/content/databases/kglite.toml
+++ b/src/content/databases/kglite.toml
@@ -2,6 +2,7 @@ name = "KGLite"
 vendor = "Kristian dF Kollsgård"
 slug = "kglite"
 description = "An embedded knowledge graph for Python written in Rust. Speaks openCypher, ships with three storage modes (in-memory, mmap, disk-backed CSR), pandas DataFrame I/O, a code_tree parser that turns source trees into call graphs across 9 languages, and a bundled MCP server for LLM agents."
+ai_roles = ["graphrag"]
 url = "https://kglite.readthedocs.io"
 github_url = "https://github.com/kkollsga/kglite"
 license = "MIT"

--- a/src/content/databases/ladybugdb.toml
+++ b/src/content/databases/ladybugdb.toml
@@ -2,6 +2,7 @@ name = "LadybugDB"
 vendor = "LadybugDB"
 slug = "ladybugdb"
 description = "A community fork of Kuzu. An embedded columnar property graph database for analytical workloads, with openCypher support, vector indices, and full-text search."
+ai_roles = ["agent-memory"]
 url = "https://ladybugdb.com/"
 github_url = "https://github.com/LadybugDB/ladybug"
 license = "MIT"

--- a/src/content/databases/memgraph.toml
+++ b/src/content/databases/memgraph.toml
@@ -2,6 +2,7 @@ name = "Memgraph"
 vendor = "Memgraph"
 slug = "memgraph"
 description = "An in-memory property graph database with ACID transactions and strong consistency. Includes the MAGE library of graph algorithms and supports real-time streaming ingestion."
+ai_roles = ["agent-memory", "graphrag"]
 url = "https://memgraph.com/"
 github_url = "https://github.com/memgraph/memgraph"
 license = "BUSL-1.1"

--- a/src/content/databases/minigraf.toml
+++ b/src/content/databases/minigraf.toml
@@ -1,6 +1,7 @@
 name = "Minigraf"
 slug = "minigraf"
 description = "An embedded, single-file graph database with Datalog queries over entity-attribute-value facts and bi-temporal time travel via per-fact transaction and valid time. Written in Rust with WebAssembly and mobile builds, targeting AI-agent memory. Successor to the archived RecallGraph."
+ai_roles = ["agent-memory"]
 url = "https://github.com/project-minigraf/minigraf"
 github_url = "https://github.com/project-minigraf/minigraf"
 license = "MIT OR Apache-2.0"

--- a/src/content/databases/neo4j.toml
+++ b/src/content/databases/neo4j.toml
@@ -2,6 +2,7 @@ name = "Neo4j"
 vendor = "Neo4j Inc"
 slug = "neo4j"
 description = "A property graph database that stores data as fixed-size records in linked lists for index-free adjacency traversal. Offers community and commercial editions with an extensive graph algorithms library."
+ai_roles = ["graphrag"]
 url = "https://neo4j.com/"
 github_url = "https://github.com/neo4j/neo4j"
 license = "GPL-3.0"

--- a/src/content/databases/neptune.toml
+++ b/src/content/databases/neptune.toml
@@ -2,6 +2,7 @@ name = "Neptune"
 vendor = "Amazon Web Services"
 slug = "neptune"
 description = "A fully managed graph database service from AWS supporting both property graph and RDF models. Available as Neptune Database (for transactional workloads) and Neptune Analytics (for analytical queries)."
+ai_roles = ["graphrag"]
 url = "https://aws.amazon.com/neptune/"
 license = "Proprietary"
 implementation_language = "C++"

--- a/src/content/databases/nodedb.toml
+++ b/src/content/databases/nodedb.toml
@@ -2,6 +2,7 @@ name = "NodeDB"
 vendor = "NodeDB-Lab"
 slug = "nodedb"
 description = "A multi-model database written in Rust that runs document, key-value, columnar, timeseries, spatial, vector, and array engines in a single binary over shared storage, with graph and full-text search as cross-engine overlays on any collection. Its graph overlay uses a CSR adjacency index with 13 built-in algorithms and a Cypher-subset MATCH syntax, and fuses graph traversal with vector search in a single query for GraphRAG. Speaks SQL over a native MessagePack protocol and the PostgreSQL wire protocol, alongside HTTP/REST, WebSocket, RESP, and ILP."
+ai_roles = ["graphrag"]
 url = "https://nodedb.dev"
 github_url = "https://github.com/NodeDB-Lab/nodedb"
 license = "BUSL-1.1"

--- a/src/content/databases/nornicdb.toml
+++ b/src/content/databases/nornicdb.toml
@@ -2,6 +2,7 @@ name = "NornicDB"
 vendor = "orneryd"
 slug = "nornicdb"
 description = "A hybrid graph and vector database written in Go with Neo4j compatibility via the Bolt protocol. Supports Cypher queries, native vector search with GPU acceleration, and a tiered memory system with episodic, semantic, and procedural decay. Includes a versioned graph ledger with temporal validity and as-of reads."
+ai_roles = ["agent-memory"]
 url = "https://github.com/orneryd/NornicDB"
 github_url = "https://github.com/orneryd/NornicDB"
 license = "MIT"

--- a/src/content/databases/ontotext-graphdb.toml
+++ b/src/content/databases/ontotext-graphdb.toml
@@ -2,6 +2,7 @@ name = "Ontotext GraphDB"
 vendor = "Graphwise"
 slug = "ontotext-graphdb"
 description = "An RDF triplestore with ACID transactions, available in free, standard, and enterprise editions. Supports semantic reasoning and inference with configurable rule sets."
+ai_roles = ["graphrag"]
 url = "https://graphwise.ai/components/graphdb/"
 license = "Proprietary"
 implementation_language = "Java"

--- a/src/content/databases/prometheux.toml
+++ b/src/content/databases/prometheux.toml
@@ -2,6 +2,7 @@ name = "Prometheux"
 vendor = "Prometheux"
 slug = "prometheux"
 description = "An ontology engine that runs graph analytics and logical reasoning over existing data sources without moving data, using the Vadalog (Datalog+/-) reasoning language. Produces deterministic, fully traceable results with row-level provenance across sources such as Snowflake, Databricks, PostgreSQL, and Neo4j."
+ai_roles = ["graphrag"]
 url = "https://www.prometheux.ai/"
 license = "Proprietary"
 type = "Other"

--- a/src/content/databases/puppygraph.toml
+++ b/src/content/databases/puppygraph.toml
@@ -2,6 +2,7 @@ name = "PuppyGraph"
 vendor = "PuppyQuery Inc"
 slug = "puppygraph"
 description = "A graph query engine that runs analytics on existing relational databases, data lakes, and warehouses without data migration."
+ai_roles = ["graphrag"]
 url = "https://www.puppygraph.com/"
 license = "Proprietary"
 type = "Property Graph"

--- a/src/content/databases/redisgraph-falkordb.toml
+++ b/src/content/databases/redisgraph-falkordb.toml
@@ -4,6 +4,7 @@ previous_vendors = ["Redis"]
 previous_names = ["RedisGraph"]
 slug = "redisgraph-falkordb"
 description = "A property graph database that runs as a Redis module, formerly RedisGraph. Uses GraphBLAS sparse matrix operations for query execution, enabling parallel graph traversal."
+ai_roles = ["agent-memory", "graphrag"]
 url = "https://www.falkordb.com/"
 github_url = "https://github.com/FalkorDB/FalkorDB"
 license = "SSPL-1.0"

--- a/src/content/databases/relationalai.toml
+++ b/src/content/databases/relationalai.toml
@@ -2,6 +2,7 @@ name = "RelationalAI"
 vendor = "RelationalAI"
 slug = "relationalai"
 description = "A cloud-native relational knowledge graph system (RKGS) that models all data as relations in Graph Normal Form and is queried with Rel, a declarative, Datalog-based modeling language. Positioned as a knowledge graph coprocessor for Snowflake, it runs in-account as a Native App on Snowpark Container Services, adding rule-based reasoning, graph analytics, and predictive and prescriptive analytics over data where it already lives. The engine is built in Julia."
+ai_roles = ["graphrag"]
 url = "https://relational.ai/"
 license = "Proprietary"
 implementation_language = "Julia"

--- a/src/content/databases/ryugraph.toml
+++ b/src/content/databases/ryugraph.toml
@@ -2,6 +2,7 @@ name = "RyuGraph"
 vendor = "Predictable Labs"
 slug = "ryugraph"
 description = "An embedded property graph database forked from Kuzu. Features columnar storage, ACID transactions, full-text search, and vector indices, targeting knowledge and context management for AI agents."
+ai_roles = ["agent-memory"]
 url = "https://www.ryugraph.io/"
 github_url = "https://github.com/predictable-labs/ryugraph"
 license = "MIT"

--- a/src/content/databases/spanner-graph.toml
+++ b/src/content/databases/spanner-graph.toml
@@ -2,6 +2,7 @@ name = "Google Cloud Spanner Graph"
 vendor = "Google"
 slug = "spanner-graph"
 description = "A graph layer within Google Cloud Spanner that enables property graph queries over relational data using GQL and SQL/PGQ. Inherits Spanner's global distribution, strong consistency, and ACID transactions."
+ai_roles = ["graphrag"]
 url = "https://cloud.google.com/spanner/docs/graph/overview"
 license = "Proprietary"
 implementation_language = "C++"

--- a/src/content/databases/stardog.toml
+++ b/src/content/databases/stardog.toml
@@ -2,6 +2,7 @@ name = "Stardog"
 vendor = "Stardog Union"
 slug = "stardog"
 description = "An RDF-based knowledge graph database with OWL 2 reasoning and property graph extensions. Includes Voicebox, an OpenAI-compatible natural language query interface via LLM integration."
+ai_roles = ["graphrag"]
 url = "https://www.stardog.com/"
 license = "Proprietary"
 implementation_language = "Java"

--- a/src/content/databases/stromadb.toml
+++ b/src/content/databases/stromadb.toml
@@ -2,6 +2,7 @@ name = "StromaDB"
 vendor = "Katsuhide Tsuruta"
 slug = "stromadb"
 description = "A source-available property graph engine written in Rust that combines typed edges, vector search, and bitemporal facts for retrieval-augmented generation workloads. Queried through a composable operator API over CLI, HTTP, and MCP rather than a graph query language."
+ai_roles = ["graphrag"]
 url = "https://stromadb.com/"
 github_url = "https://github.com/katsut/stromadb"
 license = "Elastic-2.0"

--- a/src/content/databases/surrealdb.toml
+++ b/src/content/databases/surrealdb.toml
@@ -2,6 +2,7 @@ name = "SurrealDB"
 vendor = "SurrealDB"
 slug = "surrealdb"
 description = "A multi-model database written in Rust that combines document, graph, and relational paradigms. Uses inter-document record links for graph traversals, with ACID transactions and row-level permissions."
+ai_roles = ["agent-memory", "graphrag"]
 url = "https://surrealdb.com/"
 github_url = "https://github.com/surrealdb/surrealdb"
 license = "BUSL-1.1"

--- a/src/content/databases/tigergraph.toml
+++ b/src/content/databases/tigergraph.toml
@@ -3,6 +3,7 @@ vendor = "TigerGraph"
 slug = "tigergraph"
 previous_names = ["GraphSQL"]
 description = "A distributed property graph database (formerly GraphSQL) built for massively parallel processing and graph analytics. Uses the SQL-like GSQL query language and supports ACID transactions. Available in developer, cloud, and enterprise editions."
+ai_roles = ["graphrag"]
 url = "https://www.tigergraph.com/"
 license = "Proprietary"
 implementation_language = "C++"

--- a/src/content/databases/typedb.toml
+++ b/src/content/databases/typedb.toml
@@ -3,6 +3,7 @@ vendor = "Vaticle"
 slug = "typedb"
 previous_names = ["Grakn"]
 description = "A polymorphic database that natively models inheritance hierarchies, dependencies, and conceptual schemas using its TypeQL query language. Supports clustering for scalability and a cloud-agnostic deployment model."
+ai_roles = ["graphrag"]
 url = "https://typedb.com/"
 github_url = "https://github.com/typedb/typedb"
 license = "MPL-2.0"

--- a/src/lib/ranking-boards.ts
+++ b/src/lib/ranking-boards.ts
@@ -1,7 +1,8 @@
 /**
- * Turns a RankingFile into the flat list of pages to generate. Each board becomes a page at
- * /rankings/{slug}. Only /rankings/overall/ targets the generic head terms; sub-boards lead
- * with their qualifier so they stop competing with it, and with each other.
+ * Turns a RankingFile plus catalogue metadata into the flat list of pages to generate. Each
+ * board becomes a page at /rankings/{slug}. Only /rankings/overall/ targets the generic head
+ * terms; sub-boards lead with their qualifier so they stop competing with it, and with each
+ * other.
  */
 import type { RankingFile, RankedEngine } from './rankings';
 
@@ -16,8 +17,24 @@ export interface Board {
   engines: RankedEngine[];
   /** Engines on this board flagged 'Insufficient data' (stripped from `engines`). */
   insufficientCount: number;
+  /** Whether this board is linked from the rankings directory. Direct URLs remain valid. */
+  listed: boolean;
   /** For breadcrumbs/grouping on the index page. */
-  group: 'overall' | 'type' | 'kind' | 'license' | 'query-language' | 'language' | 'movers';
+  group: 'overall' | 'type' | 'kind' | 'license' | 'query-language' | 'language' | 'segment' | 'movers';
+}
+
+/**
+ * The small amount of catalogue metadata needed to build editorial ranking segments.
+ * Keep this separate from Astro's collection type so the ranking builder stays reusable
+ * from the OG image endpoint and from page routes.
+ */
+export interface CatalogueRankingMeta {
+  slug: string;
+  kind?: string;
+  status?: string;
+  protocols?: readonly string[];
+  description?: string;
+  ai_roles?: readonly string[];
 }
 
 const splitInsufficient = (engines: RankedEngine[]): { ranked: RankedEngine[]; insufficientCount: number } => {
@@ -48,6 +65,14 @@ export const slugify = (s: string): string =>
 //   - byImplementationLanguage groups below the upstream MIN_LANGUAGE_ENGINES floor
 const SKIP_KIND = new Set(['database', 'library']);
 
+// These boards remain available as stable direct URLs, but are not useful entry points
+// from the rankings directory: Specialized is a catch-all for the `Other` type, while
+// Custom API describes an integration surface rather than a query language.
+const HIDE_FROM_RANKINGS_INDEX = {
+  type: new Set(['Specialized']),
+  queryLanguage: new Set(['Custom API']),
+};
+
 // type 'Other' and license-tier 'Other' would both want the slug "other"; relabel the
 // license one as "Source-Available" since after the recent metadata fixes it's mostly BSL.
 const LICENSE_LABEL: Record<string, string> = {
@@ -70,6 +95,101 @@ const KIND_LABEL: Record<string, string> = {
   'query-engine': 'Graph Query Engine',
   library: 'Graph Library',
 };
+
+const POSTGRES_PROTOCOL = 'PostgreSQL wire';
+
+/**
+ * These are graph layers whose primary value is querying or extending relational data,
+ * rather than operating as a separate native graph store. The extension half is discovered
+ * from the catalogue description below; these entries are the non-extension graph layers
+ * whose existing metadata expresses the same user-facing use case.
+ */
+const RELATIONAL_GRAPH_LAYER_OVERRIDES = new Set([
+  'agensgraph',
+  'bigquery-graph',
+  'ontop',
+  'postgresql-sql-pgq',
+  'prometheux',
+  'puppygraph',
+  'relationalai',
+  'spanner-graph',
+  'typegraph',
+]);
+
+const isActiveCatalogueEntry = (db: CatalogueRankingMeta): boolean =>
+  db.status !== 'inactive' && db.status !== 'deprecated';
+
+const isPostgresGraphExtension = (db: CatalogueRankingMeta): boolean =>
+  isActiveCatalogueEntry(db) && db.kind === 'extension' && db.protocols?.includes(POSTGRES_PROTOCOL) === true;
+
+const isGraphOverRelational = (db: CatalogueRankingMeta): boolean =>
+  isActiveCatalogueEntry(db) && (
+    RELATIONAL_GRAPH_LAYER_OVERRIDES.has(db.slug) ||
+    (db.kind === 'extension' && /\b(?:postgres(?:ql)?|duckdb|sqlite)\b/i.test(db.description ?? ''))
+  );
+
+// Do not infer these boards from generic AI, vector, or graph language. `ai_roles` is a
+// curated product-role classification, kept separate from the monthly ranking data.
+const hasAiRole = (db: CatalogueRankingMeta, role: 'agent-memory' | 'graphrag'): boolean =>
+  isActiveCatalogueEntry(db) && db.ai_roles?.includes(role) === true;
+
+const isAgentMemory = (db: CatalogueRankingMeta): boolean => hasAiRole(db, 'agent-memory');
+const isGraphRag = (db: CatalogueRankingMeta): boolean => hasAiRole(db, 'graphrag');
+
+interface SegmentDefinition {
+  slug: string;
+  title: string;
+  h1: string;
+  shortLabel: string;
+  blurb: string;
+  listed?: boolean;
+  match: (db: CatalogueRankingMeta) => boolean;
+}
+
+const SEGMENTS: SegmentDefinition[] = [
+  {
+    slug: 'postgresql-graph-extensions',
+    title: 'PostgreSQL Graph Extensions, Ranked Monthly',
+    h1: 'PostgreSQL Graph Extensions, Ranked Monthly',
+    shortLabel: 'PostgreSQL Extensions',
+    blurb: 'Graph extensions that run inside PostgreSQL or a PostgreSQL-compatible engine, ranked monthly across adoption, activity, community and research signals.',
+    match: isPostgresGraphExtension,
+  },
+  {
+    slug: 'graph-layers-relational-databases',
+    title: 'Graph Layers for Relational Databases, Ranked Monthly',
+    h1: 'Graph Layers for Relational Databases, Ranked Monthly',
+    shortLabel: 'Relational Graph Layers',
+    blurb: 'Graph layers that add graph capabilities to relational databases or query relational tables in place, ranked monthly across adoption, activity, community and research signals.',
+    match: isGraphOverRelational,
+  },
+  {
+    slug: 'graph-databases-agent-memory',
+    title: 'Graph Systems for Agent Memory, Ranked Monthly',
+    h1: 'Graph Systems for Agent Memory, Ranked Monthly',
+    shortLabel: 'Agent Memory',
+    blurb: 'Graph systems used as memory and context stores for AI agents. Monthly ranking by adoption, activity, community, and research.',
+    match: isAgentMemory,
+  },
+  {
+    slug: 'graph-databases-graphrag-knowledge-grounding',
+    title: 'Graph Systems for GraphRAG & Knowledge Grounding, Ranked Monthly',
+    h1: 'Graph Systems for GraphRAG & Knowledge Grounding, Ranked Monthly',
+    shortLabel: 'GraphRAG & Grounding',
+    blurb: 'Graph systems used for GraphRAG and to ground AI responses in structured knowledge. Monthly ranking by adoption, activity, community, and research.',
+    match: isGraphRag,
+  },
+  {
+    // Keep the original URL as an unlisted umbrella page for existing links.
+    slug: 'graph-databases-ai-agents',
+    title: 'Graph Systems for AI, Ranked Monthly',
+    h1: 'Graph Systems for AI, Ranked Monthly',
+    shortLabel: 'AI Graphs',
+    blurb: 'Graph systems used for agent memory, GraphRAG, or knowledge grounding. Monthly ranking by adoption, activity, community, and research.',
+    listed: false,
+    match: (db) => isAgentMemory(db) || isGraphRag(db),
+  },
+];
 
 const blurbFor = (label: string): string =>
   `${label} graph databases, ranked monthly by adoption, activity, community and research signals.`;
@@ -162,14 +282,14 @@ export interface EngineRanking { board: Board; rank: number; }
 /** Every board an engine appears on, with its rank. Ordered overall→type→kind→license→query→language→movers. */
 export function getEngineRanks(boards: Board[], slug: string): EngineRanking[] {
   const out: EngineRanking[] = [];
-  for (const b of boards) {
+  for (const b of boards.filter((board) => board.listed)) {
     const i = b.engines.findIndex((e) => e.slug === slug);
     if (i !== -1) out.push({ board: b, rank: i + 1 });
   }
   return out;
 }
 
-type BoardMeta = Omit<Board, 'engines' | 'insufficientCount'>;
+type BoardMeta = Omit<Board, 'engines' | 'insufficientCount' | 'listed'> & { listed?: boolean };
 function makeBoard(meta: BoardMeta, engines: RankedEngine[]): Board {
   const { ranked, insufficientCount } = splitInsufficient(engines);
   // Enrich the meta description with the top-3 engines for this board, so each ranking
@@ -182,7 +302,7 @@ function makeBoard(meta: BoardMeta, engines: RankedEngine[]): Board {
   } else if (top3.length >= 3 && meta.group === 'movers') {
     metaDescription = `${meta.metaDescription} Top movers: ${top3.join(', ')}.`;
   }
-  return { ...meta, metaDescription, engines: ranked, insufficientCount };
+  return { ...meta, listed: meta.listed ?? true, metaDescription, engines: ranked, insufficientCount };
 }
 
 // Build "{label} Graph Database Popularity Ranking", avoiding the duplicate-word
@@ -209,7 +329,7 @@ function gdbRankingTitle(label: string): string {
 // best-performing board on the site, so emerging standards stay in below the floor.
 const MIN_BOARD_ENGINES = 15;
 
-export function buildBoards(ranking: RankingFile): Board[] {
+export function buildBoards(ranking: RankingFile, catalogue: readonly CatalogueRankingMeta[] = []): Board[] {
   const boards: Board[] = [];
 
   boards.push(makeBoard({
@@ -231,6 +351,7 @@ export function buildBoards(ranking: RankingFile): Board[] {
       shortLabel: label,
       blurb: blurbFor(label),
       metaDescription: blurbFor(label),
+      listed: !HIDE_FROM_RANKINGS_INDEX.type.has(label),
       group: 'type',
     }, engines));
   }
@@ -249,6 +370,30 @@ export function buildBoards(ranking: RankingFile): Board[] {
     }, engines));
   }
 
+  // Editorial segments use the same monthly score as every other board, but their
+  // membership comes from catalogue metadata rather than a field already present in
+  // ranking.json. Keeping the matchers here makes it easy to add the next landscape
+  // segment without creating a second ranking page template or data format.
+  if (catalogue.length > 0) {
+    for (const segment of SEGMENTS) {
+      const eligible = new Set(
+        catalogue.filter(segment.match).map((db) => db.slug)
+      );
+      const engines = ranking.overall.filter((engine) => eligible.has(engine.slug));
+      if (engines.length === 0) continue;
+      boards.push(makeBoard({
+        slug: segment.slug,
+        title: segment.title,
+        h1: segment.h1,
+        shortLabel: segment.shortLabel,
+        blurb: segment.blurb,
+        metaDescription: segment.blurb,
+        listed: segment.listed,
+        group: 'segment',
+      }, engines));
+    }
+  }
+
   // The license group is retired: four boards, 71 impressions and zero clicks over the
   // 90 days to 2026-07-29. Ranking 71 of 143 engines by "permissive licence" was never a
   // question anyone asked, and the pages competed with the overall board for head terms.
@@ -262,6 +407,7 @@ export function buildBoards(ranking: RankingFile): Board[] {
       shortLabel: lang,
       blurb: blurbFor(lang),
       metaDescription: blurbFor(lang),
+      listed: !HIDE_FROM_RANKINGS_INDEX.queryLanguage.has(lang),
       group: 'query-language',
     }, engines));
   }
@@ -291,7 +437,7 @@ export function buildBoards(ranking: RankingFile): Board[] {
   // De-duplicate any accidental slug collisions across categories (last wins isn't ideal —
   // but with our current label maps there shouldn't be any).
   const seen = new Set<string>();
-  const exemptFromFloor = new Set(['overall', 'movers', 'query-language']);
+  const exemptFromFloor = new Set(['overall', 'movers', 'query-language', 'segment']);
   return boards.filter((b) => {
     if (seen.has(b.slug)) {
       console.warn(`[rankings] dropping board with duplicate slug "${b.slug}" (group=${b.group})`);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -54,7 +54,7 @@ const breadcrumbJsonLd = JSON.stringify({
     </ul>
 
     <h2>Rankings</h2>
-    <p><a href="/rankings/">GDB-Engines Rankings</a> is a separate monthly popularity ranking covering every active engine in the catalog. Engines are ranked overall and across boards split by data model, engine kind, license, query language, and implementation language, plus a movers board surfacing the biggest changes month-on-month.</p>
+    <p><a href="/rankings/">GDB-Engines Rankings</a> is a separate monthly popularity ranking covering every active engine in the catalog. Engines are ranked overall and across boards split by data model, engine kind, landscape segment, query language, and implementation language, plus a movers board surfacing the biggest changes month-on-month.</p>
     <p>Scores blend signals across four pillars — adoption, activity, community, and research — drawing on public data sources across the web. The methodology is fixed in advance and is not adjusted for sponsors.</p>
 
     <h2>API</h2>

--- a/src/pages/db/[slug].astro
+++ b/src/pages/db/[slug].astro
@@ -13,7 +13,8 @@ import { loadGithubStars, formatGithubStars } from '../../lib/github-stars';
 import { sortProtocols } from '../../lib/protocols';
 
 const ranking = await loadRankings();
-const boards = ranking ? buildBoards(ranking) : [];
+const catalogue = await getCollection('databases');
+const boards = ranking ? buildBoards(ranking, catalogue.map(({ data }) => data)) : [];
 
 export async function getStaticPaths() {
   const databases = await getCollection('databases');

--- a/src/pages/llms.txt.ts
+++ b/src/pages/llms.txt.ts
@@ -48,7 +48,11 @@ export const GET: APIRoute = async () =>
 
 - [Overall ranking](https://gdb-engines.com/rankings/overall/): Top graph databases by blended score, refreshed monthly.
 - [Movers](https://gdb-engines.com/rankings/movers/): Engines with the fastest-rising momentum month-over-month.
-- [Rankings index](https://gdb-engines.com/rankings/): All boards split by data model, engine kind, license, query language, and implementation language.
+- [PostgreSQL graph extensions](https://gdb-engines.com/rankings/postgresql-graph-extensions/): Graph extensions that run inside PostgreSQL or a PostgreSQL-compatible engine.
+- [Graph layers for relational databases](https://gdb-engines.com/rankings/graph-layers-relational-databases/): Graph layers that add graph capabilities to relational data or query it in place.
+- [Graph systems for agent memory](https://gdb-engines.com/rankings/graph-databases-agent-memory/): Graph systems used as memory and context stores for AI agents.
+- [Graph systems for GraphRAG and knowledge grounding](https://gdb-engines.com/rankings/graph-databases-graphrag-knowledge-grounding/): Graph systems used for GraphRAG and grounding AI responses in structured knowledge.
+- [Rankings index](https://gdb-engines.com/rankings/): All boards split by data model, engine kind, landscape segment, query language, and implementation language.
 
 ## Comparisons
 

--- a/src/pages/og/rankings/[...route].ts
+++ b/src/pages/og/rankings/[...route].ts
@@ -9,9 +9,11 @@
 import { OGImageRoute } from 'astro-og-canvas';
 import { loadRankings } from '../../../lib/rankings';
 import { buildBoards } from '../../../lib/ranking-boards';
+import { getCollection } from 'astro:content';
 
 const ranking = await loadRankings();
-const boards = ranking ? buildBoards(ranking) : [];
+const databases = await getCollection('databases');
+const boards = ranking ? buildBoards(ranking, databases.map(({ data }) => data)) : [];
 
 const pages = Object.fromEntries(
   boards.map((b) => [b.slug, { title: b.h1 }]),

--- a/src/pages/rankings/[slug].astro
+++ b/src/pages/rankings/[slug].astro
@@ -40,7 +40,7 @@ export async function getStaticPaths() {
     roundups.filter((r) => r.data.ranking_board).map((r) => [r.data.ranking_board, { slug: r.data.slug, h1: r.data.h1 }])
   );
 
-  return buildBoards(ranking).map((board) => ({
+  return buildBoards(ranking, databases.map(({ data }) => data)).map((board) => ({
     params: { slug: board.slug },
     props: {
       board,
@@ -93,6 +93,7 @@ const scoreLabel = isMovers ? 'momentum' : 'score';
   <main class="ranking-page">
     <nav class="breadcrumb"><a href="/rankings/">GDB-Engines Rankings</a> &rsaquo; {board.h1}</nav>
     <h1>{board.h1}</h1>
+    <p class="context">{board.blurb}</p>
     {top.length >= 3 ? (
       <p class="lead">
         <a href={`/db/${top[0].slug}/`}>{top[0].name}</a> leads with a {scoreLabel} of {(isMovers ? top[0].momentum : top[0].score).toFixed(1)},
@@ -127,7 +128,7 @@ const scoreLabel = isMovers ? 'momentum' : 'score';
   .breadcrumb a { color: var(--color-text-secondary); text-decoration: none; }
   .breadcrumb a:hover { text-decoration: underline; }
   h1 { font-size: 1.5rem; margin: 0 0 0.5rem; line-height: 1.2; color: var(--color-text); }
-  .blurb { color: var(--color-text-secondary); max-width: 70ch; line-height: 1.5; margin: 0.5rem 0 0.25rem; }
+  .context { color: var(--color-text-secondary); max-width: 90ch; line-height: 1.5; margin: 0.5rem 0 0.25rem; }
   .updated { color: var(--color-text-tertiary); font-size: 0.8rem; margin-bottom: 1rem; }
   .lead { color: var(--color-text); line-height: 1.55; max-width: 90ch; margin: 0.75rem 0 1.25rem; }
   .lead a { color: var(--color-text); text-decoration: underline; text-decoration-color: var(--color-border); text-underline-offset: 2px; }

--- a/src/pages/rankings/index.astro
+++ b/src/pages/rankings/index.astro
@@ -12,10 +12,11 @@ import { getCollection } from 'astro:content';
 import { buildFaviconMap } from '../../lib/favicon-map';
 
 const ranking = await loadRankings();
-const boards: Board[] = ranking ? buildBoards(ranking) : [];
+const databases = await getCollection('databases');
+const boards: Board[] = ranking ? buildBoards(ranking, databases.map(({ data }) => data)) : [];
 const generatedAt = ranking?.generatedAt;
 const updated = generatedAt ? new Date(generatedAt).toLocaleDateString('en-GB', { year: 'numeric', month: 'long' }) : null;
-const faviconMap = await buildFaviconMap(await getCollection('databases'));
+const faviconMap = await buildFaviconMap(databases);
 // Leaders of each board, logo-bearing only — a slug missing from the map has no logo.
 const leaders = (b: Board) => b.engines.map((e) => faviconMap[e.slug]).filter(Boolean).slice(0, 6);
 const overall = boards.find((b) => b.slug === 'overall');
@@ -37,12 +38,15 @@ const groupLabels: Record<Board['group'], string> = {
   license: 'By License',
   'query-language': 'By Query Language',
   language: 'By Implementation Language',
+  segment: 'By Landscape Segment',
   movers: 'Movers',
 };
 
 const grouped: Partial<Record<Board['group'], Board[]>> = {};
-for (const b of boards) (grouped[b.group] ??= []).push(b);
-const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'license', 'query-language', 'language'];
+for (const b of boards) {
+  if (b.listed) (grouped[b.group] ??= []).push(b);
+}
+const groupOrder: Board['group'][] = ['overall', 'movers', 'segment', 'type', 'kind', 'license', 'query-language', 'language'];
 ---
 <Layout
   title="GDB-Engines Rankings — Graph Database Popularity"
@@ -58,10 +62,10 @@ const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'lice
         <a href={`/db/${topOverall[0].slug}/`}>{topOverall[0].name}</a> ({topOverall[0].score.toFixed(1)}),
         <a href={`/db/${topOverall[1].slug}/`}>{topOverall[1].name}</a> ({topOverall[1].score.toFixed(1)}) and
         <a href={`/db/${topOverall[2].slug}/`}>{topOverall[2].name}</a> ({topOverall[2].score.toFixed(1)}) lead the overall ranking{updated && `, ${updated}`}.
-        Boards below split the same data by data model, engine kind, license, query language and implementation language.
+        Boards below split the same data by data model, engine kind, landscape segment, query language and implementation language.
       </p>
     ) : (
-      <p class="lead">Monthly popularity rankings for graph databases — blended scores across adoption, activity, community and research signals.</p>
+      <p class="lead">Monthly popularity rankings for graph databases, extensions and graph layers — blended scores across adoption, activity, community and research signals.</p>
     )}
     <SponsorCTA />
 
@@ -70,26 +74,50 @@ const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'lice
     {boards.length === 0 ? (
       <p class="empty">Ranking data isn't available in this build (no <code>RANKINGS_TOKEN</code> set and no local sibling checkout).</p>
     ) : (
-      groupOrder.map((g) => grouped[g] && (
-        <section>
-          <h2>{groupLabels[g]}</h2>
-          <ul class="board-cards">
-            {grouped[g]!.map((b) => (
-              <li>
-                <a href={`/rankings/${b.slug}/`}>
-                  <span class="board-name">{b.h1}</span>
-                  <CountBadge count={b.engines.length} />
-                </a>
-                <span class="board-logos">
-                  {leaders(b).map((src) => (
-                    <DatabaseLogo src={src} size={16} loading="lazy" />
-                  ))}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ))
+      <>
+        <div class="featured-boards">
+          {(['overall', 'movers'] as const).map((g) => grouped[g] && (
+            <section>
+              <h2>{groupLabels[g]}</h2>
+              <ul class="board-cards">
+                {grouped[g]!.map((b) => (
+                  <li>
+                    <a href={`/rankings/${b.slug}/`}>
+                      <span class="board-name">{b.h1}</span>
+                      <CountBadge count={b.engines.length} />
+                    </a>
+                    <span class="board-logos">
+                      {leaders(b).map((src) => (
+                        <DatabaseLogo src={src} size={16} loading="lazy" />
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+        {groupOrder.filter((g) => g !== 'overall' && g !== 'movers').map((g) => grouped[g] && (
+          <section>
+            <h2>{groupLabels[g]}</h2>
+            <ul class="board-cards">
+              {grouped[g]!.map((b) => (
+                <li>
+                  <a href={`/rankings/${b.slug}/`}>
+                    <span class="board-name">{b.h1}</span>
+                    <CountBadge count={b.engines.length} />
+                  </a>
+                  <span class="board-logos">
+                    {leaders(b).map((src) => (
+                      <DatabaseLogo src={src} size={16} loading="lazy" />
+                    ))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))}
+      </>
     )}
   </main>
 </Layout>
@@ -104,6 +132,8 @@ const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'lice
   .lead a:hover { text-decoration-color: var(--color-brand-accent); }
   .empty { background: var(--color-surface); border-left: 3px solid var(--color-border); padding: 0.75rem 1rem; color: var(--color-text-secondary); }
   section { margin: 1.5rem 0; }
+  .featured-boards { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1.25rem; }
+  .featured-boards section { min-width: 0; }
   h2 { font-size: 0.8rem; font-family: 'Familjen Grotesk', sans-serif; font-weight: 600; text-transform: uppercase; letter-spacing: -0.5px; color: var(--color-text-secondary); margin: 2rem 0 0.5rem; }
   /* Same card treatment as the /compare/ hub: the two index pages are siblings. */
   .board-cards { list-style: none; padding: 0; margin: 0; display: grid; grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr)); gap: 1.15rem; }
@@ -111,4 +141,7 @@ const groupOrder: Board['group'][] = ['overall', 'movers', 'type', 'kind', 'lice
   .board-cards a { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; color: var(--color-text); text-decoration: none; }
   .board-cards a:hover .board-name { text-decoration: underline; text-decoration-color: var(--color-brand-accent); }
   .board-logos { display: flex; gap: 0.25rem; margin-top: auto; padding-top: 0.5rem; }
+  @media (max-width: 42rem) {
+    .featured-boards { grid-template-columns: 1fr; gap: 0; }
+  }
 </style>


### PR DESCRIPTION
## Summary
- add two curated landscape boards: Graph Systems for Agent Memory and Graph Systems for GraphRAG & Knowledge Grounding
- classify catalogue entries with only the two roles, including the requested Neo4j, LadybugDB, Prometheux, Stardog, Neptune, TypeDB, GraphDB, PuppyGraph, and Cosmos DB corrections
- keep the former AI board URL as an unlisted legacy page and remove it from database sidebars
- keep the rankings directory featured cards side by side on wider mobile layouts

## Checks
- npm run build
- git diff --check